### PR TITLE
(refactor) Hide page/components for hosted version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build-css": "cross-env sass --no-source-map src:src --load-path ./node_modules --style compressed",
     "watch-css": "cross-env npm run build-css && cross-env sass --no-source-map src:src --load-path ./node_modules --style compressed --watch",
-    "start": "cross-env REACT_APP_DEV=1 REACT_APP_TV_URL=http://localhost:9999 REACT_APP_WSS_URL=ws://localhost:45000 REACT_APP_DS_URL=ws://localhost:23521 REACT_APP_WS_API_URL=wss://api-pub.bitfinex.com/ws/2 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001 IS_ELECTRON_APP=false node scripts/start.js",
-    "build": "GENERATE_SOURCEMAP=false cross-env npm run build-css && cross-env REACT_APP_TV_URL=http://localhost:9999 REACT_APP_WSS_URL=ws://localhost:45000 REACT_APP_DS_URL=ws://localhost:23521 REACT_APP_WS_API_URL=wss://api-pub.bitfinex.com/ws/2 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001 IS_ELECTRON_APP=false node scripts/build.js",
+    "start": "cross-env REACT_APP_DEV=1 REACT_APP_TV_URL=http://localhost:9999 REACT_APP_WSS_URL=ws://localhost:45000 REACT_APP_DS_URL=ws://localhost:23521 REACT_APP_WS_API_URL=wss://api-pub.bitfinex.com/ws/2 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001 REACT_APP_IS_ELECTRON_APP=false node scripts/start.js",
+    "build": "GENERATE_SOURCEMAP=false cross-env npm run build-css && cross-env REACT_APP_TV_URL=http://localhost:9999 REACT_APP_WSS_URL=ws://localhost:45000 REACT_APP_DS_URL=ws://localhost:23521 REACT_APP_WS_API_URL=wss://api-pub.bitfinex.com/ws/2 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001 REACT_APP_IS_ELECTRON_APP=false node scripts/build.js",
     "test": "cross-env npm run lint",
     "lint": "cross-env eslint src"
   },

--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -14,10 +14,10 @@ import TradingModeModal from '../TradingModeModal'
 import BadConnectionModal from '../BadConnectionModal'
 import OldFormatModal from '../OldFormatModal'
 import AOPauseModal from '../AOPauseModal'
-
 import NotificationsSidebar from '../NotificationsSidebar'
 
-import * as Routes from '../../constants/routes'
+import Routes from '../../constants/routes'
+import { isElectronApp } from '../../redux/config'
 
 import './style.css'
 
@@ -81,13 +81,17 @@ const HFUI = ({
           <Switch>
             <Redirect from='/index.html' to='/' exact />
             <Route path={Routes.tradingTerminal.path} render={() => <TradingPage />} exact />
-            <Route path={Routes.strategyEditor.path} render={() => <StrategyEditorPage />} />
+            {isElectronApp && Routes.strategyEditor && <Route path={Routes.strategyEditor.path} render={() => <StrategyEditorPage />} />}
             <Route path={Routes.marketData.path} render={() => <MarketDataPage />} />
           </Switch>
-          <TradingModeModal />
-          <BadConnectionModal />
-          <OldFormatModal />
-          <AOPauseModal />
+          {isElectronApp && (
+          <>
+            <TradingModeModal />
+            <BadConnectionModal />
+            <OldFormatModal />
+            <AOPauseModal />
+          </>
+          )}
         </>
       )}
       <NotificationsSidebar notificationsVisible={notificationsVisible} />

--- a/src/components/Navbar/Navbar.LayoutSettings.js
+++ b/src/components/Navbar/Navbar.LayoutSettings.js
@@ -12,7 +12,7 @@ import { getLocation } from '../../redux/selectors/router'
 
 import { ReactComponent as LayoutIcon } from './layout-icon.svg'
 import NavbarButton from './Navbar.Button'
-import * as Routes from '../../constants/routes'
+import Routes from '../../constants/routes'
 
 import AddLayoutComponentModal from '../AddLayoutComponentModal'
 import CreateNewLayoutModal from '../CreateNewLayoutModal'

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -9,7 +9,8 @@ import SwitchMode from '../SwitchMode'
 
 import LayoutSettings from './Navbar.LayoutSettings'
 import AppSettings from './Navbar.AppSettings'
-import * as Routes from '../../constants/routes'
+import Routes from '../../constants/routes'
+import { isElectronApp } from '../../redux/config'
 
 import './style.css'
 
@@ -36,14 +37,16 @@ const Navbar = () => {
             icon='notifications'
             onClick={() => dispatch(UIActions.switchNotifcationPanel())}
           />
-          <AppSettings />
+          {isElectronApp && <AppSettings />}
         </div>
+        {isElectronApp && (
         <div className='hfui-tradingpaper__control'>
           <div className='hfui-tradingpaper__control-toggle'>
             <p>Paper Trading</p>
             <SwitchMode />
           </div>
         </div>
+        )}
       </div>
     </div>
   )

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,3 +1,5 @@
+import { isElectronApp } from '../redux/config'
+
 export const tradingTerminal = {
   path: '/',
   label: 'Trading Terminal',
@@ -12,3 +14,11 @@ export const strategyEditor = {
   path: '/strategy-editor',
   label: 'Strategy Editor',
 }
+
+const routes = {
+  tradingTerminal,
+  marketData,
+  ...(isElectronApp ? { strategyEditor } : {}),
+}
+
+export default routes

--- a/src/pages/Authentication/Authentication.js
+++ b/src/pages/Authentication/Authentication.js
@@ -6,8 +6,10 @@ import AuthenticationInitForm from './AuthenticationInitForm'
 import AuthenticationUnlockForm from './AuthenticationUnlockForm'
 import AuthenticationConnectingForm from './AuthenticationConnectingForm'
 import { version } from '../../../package.json'
+import { isElectronApp } from '../../redux/config'
 
 import './style.css'
+import { isDevEnv } from '../../util/autologin'
 
 const Authentication = ({
   wsConnected,
@@ -16,38 +18,44 @@ const Authentication = ({
   onInit,
   onReset,
   isPaperTrading,
-}) => (
-  <div className='hfui-authenticationpage__wrapper'>
-    <div className='hfui-authenticationpage__inner'>
-      <div className='hfui-authenticationpage__inner-left'>
-        <HFIcon />
-        <div className='hfui-authenticationpage__inner-left-version-container'>
-          <div className='hfui-authenticationpage__inner-left-version'>
-            <h6>Crafted by Bitfinex</h6>
-            <p>
-              v
-              {version}
-            </p>
+}) => {
+  if (!isElectronApp && !isDevEnv()) {
+    return <AuthenticationConnectingForm />
+  }
+
+  return (
+    <div className='hfui-authenticationpage__wrapper'>
+      <div className='hfui-authenticationpage__inner'>
+        <div className='hfui-authenticationpage__inner-left'>
+          <HFIcon />
+          <div className='hfui-authenticationpage__inner-left-version-container'>
+            <div className='hfui-authenticationpage__inner-left-version'>
+              <h6>Crafted by Bitfinex</h6>
+              <p>
+                v
+                {version}
+              </p>
+            </div>
           </div>
         </div>
-      </div>
 
-      {!wsConnected ? (
-        <AuthenticationConnectingForm />
-      ) : configured ? (
-        <AuthenticationUnlockForm
-          onUnlock={onUnlock}
-          onReset={onReset}
-          isPaperTrading={isPaperTrading}
-        />
-      ) : (
-        <AuthenticationInitForm
-          onInit={onInit}
-        />
-      )}
+        {!wsConnected ? (
+          <AuthenticationConnectingForm />
+        ) : configured ? (
+          <AuthenticationUnlockForm
+            onUnlock={onUnlock}
+            onReset={onReset}
+            isPaperTrading={isPaperTrading}
+          />
+        ) : (
+          <AuthenticationInitForm
+            onInit={onInit}
+          />
+        )}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 Authentication.propTypes = {
   wsConnected: PropTypes.bool.isRequired,

--- a/src/redux/config.js
+++ b/src/redux/config.js
@@ -19,9 +19,12 @@ const MAX_STORED_TRADES = 25
 
 const PUB_WS_API_URL = process.env.REACT_APP_WS_API_URL || 'wss://api-pub.bitfinex.com/ws/2'
 
+const isElectronApp = process.env.REACT_APP_IS_ELECTRON_APP === 'true'
+
 export {
   REDUCER_PATHS,
   PUB_WS_API_URL,
   UFX_REDUCER_PATHS,
   MAX_STORED_TRADES,
+  isElectronApp,
 }

--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -14,7 +14,7 @@ import { nonce } from 'bfx-api-node-util'
 import { VOLUME_UNIT, VOLUME_UNIT_PAPER } from '@ufx-ui/bfx-containers'
 
 import types from '../../constants/ui'
-import * as Routes from '../../../constants/routes'
+import Routes from '../../../constants/routes'
 import DEFAULT_TRADING_LAYOUT from './default_layout_trading'
 import DEFAULT_MARKET_DATA_LAYOUT from './default_layout_market_data'
 import DEFAULT_TRADING_COMPONENT_STATE from './default_component_state_trading'


### PR DESCRIPTION
[Hide page/components for hosted version](https://app.asana.com/0/0/1200581919484407/f)

Description:
Hide following for hosted web version: (wont impact electron app)
- StrategyEditor page
- Login Page (Temporarily login page can be visible for development env, until we add authToken based support)
- Paper Trading switch
- Settings Modal
- some modals (<TradingModeModal />, <BadConnectionModal />, <OldFormatModal />, <AOPauseModal />) which triggers app based events. @Blaumaus  please help confirm these change related to hiding above four modals