### PR TITLE
(fix) OrderHistory: show correct pairs names

### DIFF
--- a/src/components/OrderHistory/OrderHistory.colunms.js
+++ b/src/components/OrderHistory/OrderHistory.colunms.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import _get from 'lodash/get'
+import { ORDER_HISTORY_KEYS, PrettyValue, FullDate } from '@ufx-ui/core'
+import { getPriceFromStatus, getFormatedStatus } from './OrderHistory.helpers'
+
+const {
+  ID,
+  PAIR,
+  TYPE,
+  BASE_CCY,
+  AMOUNT,
+  PRICE,
+  PRICE_AVERAGE,
+  PLACED,
+  STATUS,
+} = ORDER_HISTORY_KEYS
+
+export const ROW_MAPPING = {
+  [ID]: {
+    index: 0,
+  },
+  [BASE_CCY]: {
+    hidden: true,
+  },
+  [PAIR]: {
+    index: 1,
+    format: (value, _, data) => _get(data, 'symbol'),
+  },
+  [AMOUNT]: {
+    index: 2,
+    selector: 'originalAmount',
+    // eslint-disable-next-line react/prop-types, react/display-name
+    renderer: ({ rowData }) => {
+      const amount = _get(rowData, 'originalAmount')
+
+      return (amount < 0
+        ? <span className='hfui-red'>{amount}</span>
+        : <span className='hfui-green'>{amount}</span>
+      )
+    },
+  },
+  [PRICE]: {
+    index: 3,
+  },
+  [PRICE_AVERAGE]: {
+    index: 4,
+    // eslint-disable-next-line react/display-name
+    format: (_value, _, data) => {
+      const value = getPriceFromStatus(_get(data, 'status'))
+      return <PrettyValue value={value} sigFig={5} fadeTrailingZeros />
+    },
+  },
+  [TYPE]: {
+    index: 5,
+    cellStyle: { width: '20%' },
+  },
+  [STATUS]: {
+    index: 6,
+    format: (value, _, data) => {
+      return getFormatedStatus(_get(data, 'status'))
+    },
+  },
+  [PLACED]: {
+    index: 7,
+    selector: 'created',
+    // eslint-disable-next-line react/display-name
+    format: (value, _, data) => {
+      return <FullDate ts={_get(data, 'created')} />
+    },
+  },
+}

--- a/src/components/OrderHistory/OrderHistory.container.js
+++ b/src/components/OrderHistory/OrderHistory.container.js
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux'
+import { getOrderHistory } from '../../redux/selectors/ws'
 import OrderHistory from './OrderHistory'
 
 const mapStateToProps = (state = {}) => ({
-  orders: state.ws.orderHistory?.orders,
+  orders: getOrderHistory(state),
 })
 
 export default connect(mapStateToProps)(OrderHistory)

--- a/src/components/OrderHistory/OrderHistory.helpers.js
+++ b/src/components/OrderHistory/OrderHistory.helpers.js
@@ -1,14 +1,3 @@
-const symbolToLabel = (symbol) => {
-  if (symbol.includes(':')) {
-    let [base, quote] = symbol.split(':') //eslint-disable-line
-    if (base.includes('t')) {
-      base = base.substring(1, base.length)
-    }
-    return `${base}/${quote}`
-  }
-  return `${symbol.substring(1, 4)}/${symbol.substring(4)}`
-}
-
 const getPriceFromStatus = (status) => {
   if (!status.includes('@')) {
     return '0.00'
@@ -21,7 +10,6 @@ const getFormatedStatus = (status) => {
 }
 
 export {
-  symbolToLabel,
   getPriceFromStatus,
   getFormatedStatus,
 }

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -1,83 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import _get from 'lodash/get'
+
 import _isEmpty from 'lodash/isEmpty'
 import {
-  OrderHistory as UfxOrderHistory, ORDER_HISTORY_KEYS, PrettyValue, FullDate,
+  OrderHistory as UfxOrderHistory,
 } from '@ufx-ui/core'
 import Panel from '../../ui/Panel'
 import useSize from '../../hooks/useSize'
-import { symbolToLabel, getPriceFromStatus, getFormatedStatus } from './OrderHistory.helpers'
+import { ROW_MAPPING } from './OrderHistory.colunms'
 import './style.css'
-
-const {
-  ID,
-  PAIR,
-  TYPE,
-  BASE_CCY,
-  AMOUNT,
-  PRICE,
-  PRICE_AVERAGE,
-  PLACED,
-  STATUS,
-} = ORDER_HISTORY_KEYS
-
-export const ROW_MAPPING = {
-  [ID]: {
-    index: 0,
-  },
-  [BASE_CCY]: {
-    hidden: true,
-  },
-  [PAIR]: {
-    index: 1,
-    format: (value, _, data) => {
-      return symbolToLabel(_get(data, 'symbol'))
-    },
-  },
-  [AMOUNT]: {
-    index: 2,
-    selector: 'originalAmount',
-    // eslint-disable-next-line react/prop-types, react/display-name
-    renderer: ({ rowData }) => {
-      const amount = _get(rowData, 'originalAmount')
-
-      return (amount < 0
-        ? <span className='hfui-red'>{amount}</span>
-        : <span className='hfui-green'>{amount}</span>
-      )
-    },
-  },
-  [PRICE]: {
-    index: 3,
-  },
-  [PRICE_AVERAGE]: {
-    index: 4,
-    // eslint-disable-next-line react/display-name
-    format: (_value, _, data) => {
-      const value = getPriceFromStatus(_get(data, 'status'))
-      return <PrettyValue value={value} sigFig={5} fadeTrailingZeros />
-    },
-  },
-  [TYPE]: {
-    index: 5,
-    cellStyle: { width: '20%' },
-  },
-  [STATUS]: {
-    index: 6,
-    format: (value, _, data) => {
-      return getFormatedStatus(_get(data, 'status'))
-    },
-  },
-  [PLACED]: {
-    index: 7,
-    selector: 'created',
-    // eslint-disable-next-line react/display-name
-    format: (value, _, data) => {
-      return <FullDate ts={_get(data, 'created')} />
-    },
-  },
-}
 
 const OrderHistory = ({
   onRemove, dark, orders,

--- a/src/redux/reducers/ws/order_history.js
+++ b/src/redux/reducers/ws/order_history.js
@@ -2,7 +2,7 @@ import types from '../../constants/ws'
 import { orderAdapter } from '../../adapters/ws'
 
 const getInitialState = () => {
-  return {}
+  return []
 }
 
 export default (state = getInitialState(), action = {}) => {
@@ -11,15 +11,11 @@ export default (state = getInitialState(), action = {}) => {
   switch (type) {
     case types.DATA_ORDER_CLOSE: {
       const { order = [] } = payload
-      const { orders = [] } = state
       const o = orderAdapter(order)
-      return {
+      return [
+        o,
         ...state,
-        orders: [
-          o,
-          ...orders,
-        ],
-      }
+      ]
     }
 
     default: {

--- a/src/redux/selectors/ws/get_order_history.js
+++ b/src/redux/selectors/ws/get_order_history.js
@@ -10,9 +10,7 @@ const orderHistory = (state) => {
   return _get(state, `${path}.orderHistory`, [])
 }
 
-const allMarkets = state => getMarketsObject(state)
-
-const orderHistoryWithReplacedPairs = createSelector([allMarkets, orderHistory], (markets, orders) => {
+const orderHistoryWithReplacedPairs = createSelector([getMarketsObject, orderHistory], (markets, orders) => {
   return _map(orders, (order) => {
     const { symbol } = order
     const currentMarket = markets[symbol]

--- a/src/redux/selectors/ws/get_order_history.js
+++ b/src/redux/selectors/ws/get_order_history.js
@@ -1,0 +1,23 @@
+import _get from 'lodash/get'
+import _map from 'lodash/map'
+import { createSelector } from 'reselect'
+import { REDUCER_PATHS } from '../../config'
+import { getMarketsObject } from '../meta'
+
+const path = REDUCER_PATHS.WS
+
+const orderHistory = (state) => {
+  return _get(state, `${path}.orderHistory`, [])
+}
+
+const allMarkets = state => getMarketsObject(state)
+
+const orderHistoryWithReplacedPairs = createSelector([allMarkets, orderHistory], (markets, orders) => {
+  return _map(orders, (order) => {
+    const { symbol } = order
+    const currentMarket = markets[symbol]
+    return { ...order, symbol: currentMarket.uiID }
+  }, [])
+})
+
+export default orderHistoryWithReplacedPairs

--- a/src/redux/selectors/ws/index.js
+++ b/src/redux/selectors/ws/index.js
@@ -26,6 +26,7 @@ import getAPICredentials from './get_api_credentials'
 import getAllSyncRanges from './get_all_sync_ranges'
 import isWrongAPIKeys from './is_wrong_api_keys'
 import isValidatingAPIKeys from './is_validating_api_keys'
+import getOrderHistory from './get_order_history'
 
 import getBacktestState from './get_backtest_state'
 import getBacktestData from './get_backtest_data'
@@ -48,6 +49,7 @@ export {
   getChannelByID,
   getChannelRequirements,
   getAllChannelRequirements,
+  getOrderHistory,
 
   getSyncRanges,
   isSyncingCandles,


### PR DESCRIPTION
ticket - https://app.asana.com/0/1200372033300327/1200650644717570

1. Created memoized selector
2. Using array instead of object with orderHistory
3. Separated row mapping logic

