### PR TITLE
(fix) scroll for active algo orders modal's table

### DIFF
--- a/src/components/ActiveAlgoOrdersModal/style.scss
+++ b/src/components/ActiveAlgoOrdersModal/style.scss
@@ -1,5 +1,12 @@
 @import '../../variables.scss';
 
+.hfui-active-ao-modal__wrapper {
+  .modal__body {
+    max-height: 500px;
+    overflow: auto;
+  }
+}
+
 .hfui-active-ao-modal__table {
   margin: 0 spacing(-0.75);
 


### PR DESCRIPTION
ASANA Ticket: [Bug: when there is a lot of algo orders no scroll bar on modal](https://app.asana.com/0/1125859137800433/1200649421861583/f)

UI Demonstration:
Before:
![Screenshot from 2021-07-26 14-25-13](https://user-images.githubusercontent.com/35810911/127025350-0fbed74d-8be1-44f6-ba44-f5e83bec97d2.png)

After:
![Screenshot from 2021-07-26 18-58-56](https://user-images.githubusercontent.com/35810911/127025406-b1660cba-5794-4e52-9ba9-2614b4282660.png)
