### PR TITLE
(fix) Order Tables: using uiID property for showing corrent ccy pair and symbol property for searching and cancelling

### DIFF
--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
@@ -25,7 +25,7 @@ export default (authToken, cancelOrder, gaCancelOrder) => [{
   dataKey: 'args.symbol',
   width: 140,
   flexGrow: 1.4,
-  cellRenderer: ({ rowData = {} }) => rowData.args?.symbol,
+  cellRenderer: ({ rowData = {} }) => rowData.args?.uiID,
 }, {
   label: 'Label',
   dataKey: 'label',

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -14,7 +14,7 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }) => [{
   dataKey: 'symbol',
   width: 145,
   flexGrow: 1.45,
-  cellRenderer: ({ rowData = {} }) => rowData.symbol,
+  cellRenderer: ({ rowData = {} }) => rowData.uiID,
 }, {
   label: 'Type',
   dataKey: 'type',

--- a/src/redux/selectors/ws/get_algo_orders.js
+++ b/src/redux/selectors/ws/get_algo_orders.js
@@ -15,7 +15,7 @@ const algoOrdersWithReplacedPairs = createSelector([allMarkets, algoOrders], (ma
   return _map(orders, (order) => {
     const { symbol } = order.args
     const currentMarket = markets[symbol]
-    return { ...order, args: { ...order.args, symbol: currentMarket.uiID } }
+    return { ...order, args: { ...order.args, uiID: currentMarket.uiID } }
   }, [])
 })
 

--- a/src/redux/selectors/ws/get_all_orders.js
+++ b/src/redux/selectors/ws/get_all_orders.js
@@ -15,7 +15,7 @@ const atomicOrdersWithReplacedPairs = createSelector([allMarkets, atomicOrders],
   return _map(orders, (order) => {
     const { symbol } = order
     const currentMarket = markets[symbol]
-    return { ...order, symbol: currentMarket.uiID }
+    return { ...order, uiID: currentMarket.uiID }
   }, [])
 })
 


### PR DESCRIPTION
ticket - https://app.asana.com/0/1125859137800433/1200671471634370

![Снимок экрана от 2021-07-27 22-37-17](https://user-images.githubusercontent.com/81973123/127217199-560f093a-a488-4790-9fa7-9871a45849c5.png)

"uiID" property only for render, "symbol" - for another tasks
