### PR TITLE
(fix) strategy-editor: tour is open on 3/3 for first login

### DIFF
--- a/src/components/Joyride/index.js
+++ b/src/components/Joyride/index.js
@@ -1,7 +1,9 @@
-import { STATUS } from 'react-joyride'
+import { STATUS, ACTIONS, EVENTS } from 'react-joyride'
 import Joyride from './Joyride'
 import * as STEPS from './Joyride.steps'
 
 export default Joyride
 
-export { STEPS, STATUS }
+export {
+  STEPS, STATUS, ACTIONS, EVENTS, Joyride,
+}


### PR DESCRIPTION
[Regression: tour on strategy editor is open on 3/3](https://app.asana.com/0/1125859137800433/1200748655325739/f)

Description:
When strategy editor is open tour callback event occurs even before tour step-targets are rendered, so it fails with error: target not found, this could be because of lazy-loading
solution: used controlled component as recommended in react-joyride, and delayed tour start by 200 ms