### PR TITLE
(improvement)  improve keyboard navigation for login page

### DIFF
--- a/src/pages/Authentication/AuthenticationUnlockForm.js
+++ b/src/pages/Authentication/AuthenticationUnlockForm.js
@@ -99,7 +99,7 @@ const AuthenticationUnlockForm = ({ isPaperTrading, onUnlock: _onUnlock, onReset
       </form>
 
       <div className='hfui-authenticationpage__clear'>
-        <p>Alternatively, clear your credentials &amp; and stored data to set a new password.</p>
+        <p>Alternatively, clear your credentials and stored data to set a new password.</p>
 
         <Button
           onClick={onReset}

--- a/src/pages/Authentication/style.scss
+++ b/src/pages/Authentication/style.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import "../../variables.scss";
 
 .hfui-authenticationpage__wrapper {
   height: 100%;
@@ -133,7 +133,7 @@
   width: 400px;
   margin-top: 16px;
 
-  &.ufx-dropdown .dropdown-field {
+  &.ufx-dropdown .dropdown-field:not(:focus) {
     background-color: $panel-background-color;
   }
 }

--- a/src/ui/Input/Input.js
+++ b/src/ui/Input/Input.js
@@ -58,7 +58,7 @@ class Input extends React.PureComponent {
             type='button'
             onClick={() => this.toggleShow()}
           >
-            {hidden ? <Icon name='eye' role='button' aria-label='Show' tabIndex={0} /> : <Icon name='eye-slash' role='button' aria-label='Hide' tabIndex={0} />}
+            {hidden ? <Icon name='eye' /> : <Icon name='eye-slash' />}
           </button>
         </div>
       )


### PR DESCRIPTION
Description:

- because of setting tab-index on both button and icon, focus is set two times on hide/show button and icon, removed tab-index from icon
- improve focus style for dropdown
- update `Alternatively, clear your credentials &amp; and stored data` to `Alternatively, clear your credentials and stored data` 