### PR TITLE
(fix) overflow for modal dropdown

### DIFF
--- a/src/ui/Modal/style.scss
+++ b/src/ui/Modal/style.scss
@@ -2,7 +2,7 @@
 
 .ufx-dialog.ufx-dialog {
   .modal {
-    overflow: auto;
+    overflow: visible;
 
     .error {
       font-size: 12px;


### PR DESCRIPTION
ASANA Ticket: [Add component dropdown extracted is not outside modal](https://app.asana.com/0/1125859137800433/1200835573070802/f)

UI Demonstration:
![Screenshot from 2021-08-24 11-56-22](https://user-images.githubusercontent.com/35810911/130597100-fac98f76-0bba-4756-921c-0bfa6103b727.png)
