### PR TITLE
(fix) bad connection modal on app start everytime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3116,9 +3116,9 @@
       }
     },
     "@ufx-ui/bfx-containers": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@ufx-ui/bfx-containers/-/bfx-containers-0.10.8.tgz",
-      "integrity": "sha512-WBUnhhjqqP5t0yDPXPmObABQkb5SkTXBfw+edsJ/6t4fDuoezEoAeCxR9bzACASaQh0PU3UDlizMdTP9L5PEUQ==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@ufx-ui/bfx-containers/-/bfx-containers-0.10.9.tgz",
+      "integrity": "sha512-2zUBLWIGneGJJOfyMyrLVN/VR2MAX0LKnCbsevB4n0/gbHw7wagOCO2lpuk5aGIrJGXAk+kw9hIK3CIMjTKDvw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.28",
         "@fortawesome/free-regular-svg-icons": "^5.13.1",
@@ -15641,9 +15641,9 @@
       }
     },
     "react-router-dom": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.1.tgz",
-      "integrity": "sha512-xhFFkBGVcIVPbWM2KEYzED+nuHQPmulVa7sqIs3ESxzYd1pYg8N8rxPnQ4T2o1zu/2QeDUWcaqST131SO1LR3w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.2.2",
     "@projectstorm/react-diagrams": "^5.3.2",
-    "@ufx-ui/bfx-containers": "0.10.8",
+    "@ufx-ui/bfx-containers": "0.10.9",
     "@ufx-ui/core": "0.10.8",
     "axios": "^0.21.1",
     "bfx-api-node-models": "^1.4.1",
@@ -111,6 +111,7 @@
     "prop-types": "^15.7.2",
     "randomcolor": "^0.5.4",
     "react": "^17.0.2",
+    "react-beforeunload": "^2.5.1",
     "react-codemirror2": "^7.2.1",
     "react-datepicker": "^3.3.0",
     "react-dev-utils": "^11.0.4",

--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -4,6 +4,7 @@ import { Route, Switch, Redirect } from 'react-router'
 import PropTypes from 'prop-types'
 import _isFunction from 'lodash/isFunction'
 
+import useInjectBfxData from '../../hooks/useInjectBfxData'
 import StrategyEditorPage from '../../pages/StrategyEditor'
 import NotificationsSidebar from '../NotificationsSidebar'
 import closeElectronApp from '../../redux/helpers/close_electron_app'
@@ -37,6 +38,8 @@ const HFUI = ({
   shouldShowAOPauseModalState,
   settingsShowAlgoPauseInfo,
 }) => {
+  useInjectBfxData()
+
   function unloadHandler() {
     if (authToken !== null) {
       onUnload(authToken, currentMode)

--- a/src/hooks/useInjectBfxData.js
+++ b/src/hooks/useInjectBfxData.js
@@ -1,0 +1,62 @@
+// https://github.com/bitfinexcom/ufx-ui/blob/staging/packages/bfx-containers/src/hooks/useInjectBfxData.js -> removed not required ap calls for HF
+
+import { useEffect } from 'react'
+import { useBeforeunload } from 'react-beforeunload'
+import { useSelector, useDispatch } from 'react-redux'
+import { reduxActions, reduxSelectors } from '@ufx-ui/bfx-containers'
+
+import { getSocket } from '../redux/selectors/ws'
+import { isElectronApp } from '../redux/config'
+
+const {
+  requestCurrenciesInfo,
+  requestSymbolDetails,
+  WSConnectThrottled,
+  WSDisconnect,
+} = reduxActions
+
+const { getWSConnected } = reduxSelectors
+
+const useInjectBfxData = () => {
+  const dispatch = useDispatch()
+  const socket = useSelector(getSocket())
+  const isAPIServerConnected = socket?.status === 'online'
+
+  // start: fetch common data used across all ufx-containers
+  useEffect(() => {
+    /*
+      electron-app: api will be fetched on localhost:45001, which will be available once api-server is started
+      hosted-app: can fetch early without waiting for api-server
+    */
+    if (!isElectronApp || isAPIServerConnected) {
+      dispatch(requestCurrenciesInfo())
+      dispatch(requestSymbolDetails())
+    }
+  }, [dispatch, isAPIServerConnected])
+
+  // end: fetch common data used across all containers
+
+  // start: websocket connection
+  const isWSConnected = useSelector(getWSConnected)
+
+  // connect/disconnect websocket
+  useEffect(() => {
+    if (!isWSConnected) {
+      WSConnectThrottled(dispatch)
+    }
+  }, [dispatch, isWSConnected])
+
+  // disconnect before page unload
+  useBeforeunload(() => {
+    dispatch(WSDisconnect())
+  })
+
+  useEffect(() => () => {
+    if (isWSConnected) {
+      dispatch(WSDisconnect())
+    }
+  }, [dispatch, isWSConnected])
+  // end: websocket connection
+}
+
+export default useInjectBfxData

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { StoreProvider as UfxStoreProvider } from '@ufx-ui/core'
-import { useInjectBfxData } from '@ufx-ui/bfx-containers'
 import Debug from 'debug'
 import Manifest from '../package.json'
 
@@ -41,7 +40,6 @@ const config = {
 }
 
 const HFUIWrapper = () => {
-  useInjectBfxData()
   useAuthToken()
 
   return (

--- a/src/redux/middleware/ws/on_close.js
+++ b/src/redux/middleware/ws/on_close.js
@@ -1,7 +1,16 @@
+import _isNil from 'lodash/isNil'
 import WSActions from '../../actions/ws'
 import UIActions from '../../actions/ui'
+import { getSocket } from '../../selectors/ws'
 
 export default (alias, store) => () => {
-  store.dispatch(UIActions.changeBadInternetConnectionState(true))
+  const state = store.getState()
+  const socket = getSocket(alias)(state)
+
+  // do not show bad-connection-modal when connecting first time and it fails i.e. when lastActivity = null
+  if (!_isNil(socket?.lastActivity)) {
+    store.dispatch(UIActions.changeBadInternetConnectionState(true))
+  }
+
   store.dispatch(WSActions.disconnected(alias))
 }

--- a/src/redux/reducers/ws/socket.js
+++ b/src/redux/reducers/ws/socket.js
@@ -57,7 +57,7 @@ export default function (state = initialState(), action = {}) {
         [alias]: {
           ...state[alias],
           status: 'offline',
-          lastActivity: null,
+          lastActivity,
         },
       }
     }

--- a/src/redux/sagas/ws/worker_connection.js
+++ b/src/redux/sagas/ws/worker_connection.js
@@ -11,10 +11,16 @@ const URLS = {
   [WSTypes.ALIAS_API_SERVER]: process.env.REACT_APP_WSS_URL,
   [WSTypes.ALIAS_DATA_SERVER]: process.env.REACT_APP_DS_URL,
 }
-const CHECK_CONNECTION_EVERY_MS = 10 * 1000
+const CHECK_CONNECTION_EVERY_MS = 10 * 1000 // 10 sec
+const CHECK_CONNECTION_INITIAL_DELAY = 8 * 1000 // 8 sec
 const debug = Debug('hfui:rx:s:ws-hfui:worker-connection')
 
 export default function* () {
+  // on app start, wait for port to open before attempting api/ds ws connection
+  if (isElectronApp) {
+    yield delay(CHECK_CONNECTION_INITIAL_DELAY)
+  }
+
   while (true) {
     const sockets = yield select(getSockets)
     const keys = Object.keys(sockets)


### PR DESCRIPTION
Fixes: https://github.com/bitfinexcom/bfx-hf-ui/issues/571

Issue:
When electron app is started it immediately attempts connection with localhost:45000 and localhost:23521. It fails since server not started and port is not open yet.

Solution:
- added initial delay of 8s, before attempting first connection
- delayed localhost:45001 call until api-server (localhost:45000) is connected
- added check to not show bad-connection-modal if connection is failed on first attempt when app is started
- customised `useInjectBfxData` hook for HF, so api calls can be delayed until api-server is connected
- calling `useInjectBfxData` from HFUI.js so can be invoked on home-page and not only on login-page