### PR TITLE
(fix) hosted-app: sometimes tickerlist is empty

### DIFF
--- a/src/redux/reducers/meta/markets.js
+++ b/src/redux/reducers/meta/markets.js
@@ -4,10 +4,8 @@ import _reduce from 'lodash/reduce'
 import types from '../../constants/ws'
 import marketTypes from '../../constants/market'
 
-const EMPTY_OBJ = {}
-
 const getInitialState = () => {
-  return EMPTY_OBJ
+  return {}
 }
 
 export default (state = getInitialState(), action = {}) => {
@@ -15,12 +13,12 @@ export default (state = getInitialState(), action = {}) => {
 
   switch (type) {
     case types.DATA_MARKETS: {
-      const { markets = EMPTY_OBJ } = payload
+      const { markets = {} } = payload
 
       return _reduce(markets, (acc, market) => {
         acc[market.wsID] = market
         return acc
-      }, EMPTY_OBJ)
+      }, {})
     }
 
     case marketTypes.SET_CCY_FULL_NAMES: {
@@ -60,7 +58,7 @@ export default (state = getInitialState(), action = {}) => {
         acc[key] = newMarketObject
 
         return acc
-      }, EMPTY_OBJ)
+      }, {})
       return newState
     }
     case marketTypes.SET_PERPS_NAMES: {
@@ -82,7 +80,7 @@ export default (state = getInitialState(), action = {}) => {
           acc[key] = { ...market, uiID: perpID, isPerp: true }
         }
         return acc
-      }, EMPTY_OBJ)
+      }, {})
       return newState
     }
 

--- a/src/redux/reducers/zendesk/index.js
+++ b/src/redux/reducers/zendesk/index.js
@@ -6,8 +6,6 @@ const getInitialState = () => ({
   ccyArticleIdsMap: [],
 })
 
-const EMPTY_OBJ = {}
-
 const reducer = (state = getInitialState(), action) => {
   const { type, payload = null } = action
   switch (type) {
@@ -17,7 +15,7 @@ const reducer = (state = getInitialState(), action) => {
         const [ccy, id] = element
         acc[ccy] = id
         return acc
-      }, EMPTY_OBJ)
+      }, {})
       return { ...state, ccyArticleIdsMap: newState }
     }
     case zendeskTypes.SET_CCY_ARTICLE: {


### PR DESCRIPTION
Issue: In market reducer, using same object reference (EMPTY_OBJ) mutates state and so it mutates new markets updates.

Solution: `EMPTY_OBJ/EMPTY_ARR` should only be used in selectors for better performance when respective state is empty, it should not be used in reducers