### PR TITLE
(fix) orderform: fix tooltip position and cursor style

### DIFF
--- a/src/components/OrderForm/FieldComponents/input.checkbox.js
+++ b/src/components/OrderForm/FieldComponents/input.checkbox.js
@@ -1,7 +1,7 @@
 import React, { memo } from 'react'
 import ClassNames from 'classnames'
 import PropTypes from 'prop-types'
-import { Checkbox } from '@ufx-ui/core'
+import { Checkbox, Tooltip } from '@ufx-ui/core'
 import _toUpper from 'lodash/toUpper'
 
 import { renderString } from './fields.helpers'
@@ -9,17 +9,18 @@ import { renderString } from './fields.helpers'
 const CheckboxInput = memo(({
   id, value, def: { label, customHelp } = {}, onChange, disabled, renderData,
 }) => (
-  <div className={ClassNames('hfui-orderform__input inline', { disabled })}>
-    <Checkbox
-      id={id}
-      checked={!!value}
-      onChange={onChange}
-      disabled={disabled}
-      helpMessage={customHelp}
-      helpMessageClassName='__react-tooltip __react_component_tooltip'
-      label={_toUpper(renderString(label, renderData))}
-    />
-  </div>
+  <Tooltip content={customHelp} className='__react-tooltip __react_component_tooltip'>
+    <div className={ClassNames('hfui-orderform__input inline', { disabled })}>
+      <Checkbox
+        id={id}
+        checked={!!value}
+        onChange={onChange}
+        disabled={disabled}
+        label={_toUpper(renderString(label, renderData))}
+        className='hfui-help-checkbox'
+      />
+    </div>
+  </Tooltip>
 ))
 
 CheckboxInput.DEFAULT_VALUE = false

--- a/src/components/OrderForm/FieldComponents/input.checkbox.js
+++ b/src/components/OrderForm/FieldComponents/input.checkbox.js
@@ -9,18 +9,20 @@ import { renderString } from './fields.helpers'
 const CheckboxInput = memo(({
   id, value, def: { label, customHelp } = {}, onChange, disabled, renderData,
 }) => (
-  <Tooltip content={customHelp} className='__react-tooltip __react_component_tooltip'>
-    <div className={ClassNames('hfui-orderform__input inline', { disabled })}>
-      <Checkbox
-        id={id}
-        checked={!!value}
-        onChange={onChange}
-        disabled={disabled}
-        label={_toUpper(renderString(label, renderData))}
-        className='hfui-help-checkbox'
-      />
-    </div>
-  </Tooltip>
+  <div className={ClassNames('hfui-orderform__input inline', { disabled })}>
+    <Checkbox
+      id={id}
+      checked={!!value}
+      onChange={onChange}
+      disabled={disabled}
+      className='hfui-help-checkbox'
+      label={(
+        <Tooltip content={customHelp} className='__react-tooltip __react_component_tooltip'>
+          {_toUpper(renderString(label, renderData))}
+        </Tooltip>
+      )}
+    />
+  </div>
 ))
 
 CheckboxInput.DEFAULT_VALUE = false

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import "../../variables.scss";
 
 .hfui-orderform__wrapper {
   .react-datepicker-popper {
@@ -312,6 +312,16 @@
 
   .hfui-orderform__input {
     margin-bottom: 0;
+  }
+}
+
+.hfui-help-checkbox {
+  .ufx-label {
+    cursor: help;
+
+    &::after {
+      cursor: pointer;
+    }
   }
 }
 


### PR DESCRIPTION
Task:
- use cursor:help for label and cursor:pointer for checkbox icon
- fix tooltip position

Before:
<img width="642" alt="Screenshot 2021-09-19 at 5 00 19 PM" src="https://user-images.githubusercontent.com/29878604/133926199-323324f2-ec2a-420d-bbd9-87d3d1966b81.png">


After:
<img width="642" alt="Screenshot 2021-09-19 at 4 59 51 PM" src="https://user-images.githubusercontent.com/29878604/133926202-422b2767-2642-41a3-8518-7cc2900dc363.png">

