### PR TITLE
(improvement) use currency:sym mapping for currency/pair representation

### DIFF
--- a/src/components/BalancesTable/BalancesTable.columns.js
+++ b/src/components/BalancesTable/BalancesTable.columns.js
@@ -11,7 +11,7 @@ const STYLES = {
   available: { justifyContent: 'flex-end' },
 }
 
-export default () => [{
+export default (getCurrencySymbol) => [{
   label: 'Context',
   dataKey: 'context',
   width: 120,
@@ -22,7 +22,7 @@ export default () => [{
   dataKey: 'currency',
   width: 100,
   flexGrow: 1,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.currency),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(getCurrencySymbol(rowData?.currency)),
 }, {
   label: 'Total',
   dataKey: 'balance',

--- a/src/components/BalancesTable/BalancesTable.js
+++ b/src/components/BalancesTable/BalancesTable.js
@@ -1,9 +1,13 @@
 import React, { memo } from 'react'
+import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import { VirtualTable } from '@ufx-ui/core'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
 import BalancesTableColumns from './BalancesTable.columns'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 // balance < 0.000000004 will be rounded and shown as 0.00000000, so hide at this threshold
 const DUST_THRESHOLD = 0.000000004
@@ -16,6 +20,8 @@ const BalancesTable = ({
     ? data.filter(b => +b.balance > DUST_THRESHOLD)
     : data
 
+  const getCurrencySymbol = useSelector(getCurrencySymbolMemo)
+
   if (_isEmpty(filtered)) {
     return (
       <p className='empty'>No balances available</p>
@@ -25,7 +31,7 @@ const BalancesTable = ({
   return (
     <VirtualTable
       data={filtered}
-      columns={BalancesTableColumns()}
+      columns={BalancesTableColumns(getCurrencySymbol)}
       defaultSortBy='context'
       defaultSortDirection='ASC'
     />

--- a/src/components/ChartPanel/ChartPanel.container.js
+++ b/src/components/ChartPanel/ChartPanel.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
 import ChartPanel from './ChartPanel'
 import UIActions from '../../redux/actions/ui'
@@ -12,6 +13,7 @@ const mapStateToProps = (state = {}, ownProps = {}) => {
     savedState: getComponentState(state, layoutID, 'trades', id),
     activeMarket: getActiveMarket(state),
     markets: getMarkets(state),
+    getCurrencySymbol: reduxSelectors.getCurrencySymbolMemo(state),
   }
 }
 

--- a/src/components/ChartPanel/ChartPanel.js
+++ b/src/components/ChartPanel/ChartPanel.js
@@ -6,12 +6,14 @@ import Panel from '../../ui/Panel'
 import Chart from '../Chart'
 import MarketSelect from '../MarketSelect'
 import './style.css'
+import { getPairFromMarket } from '../../util/market'
 
 const ChartPanel = ({
   dark, label, onRemove, moveable, removeable, showChartMarket, markets, canChangeMarket,
-  activeMarket, savedState: { currentMarket: _currentMarket }, saveState, layoutID, layoutI, showMarket,
+  activeMarket, savedState: { currentMarket: _currentMarket }, saveState, layoutID, layoutI, showMarket, getCurrencySymbol,
 }) => {
   const [currentMarket, setCurrentMarket] = useState(_currentMarket || activeMarket)
+  const currentPair = getPairFromMarket(currentMarket, getCurrencySymbol)
 
   useEffect(() => {
     if (_isEmpty(_currentMarket) && activeMarket.restID !== currentMarket.restID) {
@@ -58,7 +60,7 @@ const ChartPanel = ({
       removeable={removeable}
       showChartMarket={showChartMarket}
       chartMarketSelect={showChartMarket && canChangeMarket && renderMarketDropdown()}
-      headerComponents={showMarket && !canChangeMarket && <p>{currentMarket.uiID}</p>}
+      headerComponents={showMarket && !canChangeMarket && <p>{currentPair}</p>}
       className='hfui-chart__wrapper'
     >
       <Chart market={currentMarket} />
@@ -89,6 +91,7 @@ ChartPanel.propTypes = {
     ])),
   }),
   markets: PropTypes.objectOf(PropTypes.object),
+  getCurrencySymbol: PropTypes.func.isRequired,
 }
 
 ChartPanel.defaultProps = {

--- a/src/components/ExchangeInfoBar/ExchangeInfoBar.container.js
+++ b/src/components/ExchangeInfoBar/ExchangeInfoBar.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 import _isEqual from 'lodash/isEqual'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
 import WSActions from '../../redux/actions/ws'
 import UIActions from '../../redux/actions/ui'
@@ -15,6 +16,8 @@ import { getTicker, getTickersArray, getMarkets } from '../../redux/selectors/me
 import ExchangeInfoBar from './ExchangeInfoBar'
 import { getActiveMarketCcyId } from '../../redux/selectors/zendesk'
 
+const { getCurrencySymbolMemo } = reduxSelectors
+
 const mapStateToProps = (state = {}) => {
   const activeMarket = getActiveMarket(state)
 
@@ -29,6 +32,7 @@ const mapStateToProps = (state = {}) => {
     tickersVolumeUnit: getTickersVolumeUnit(state),
     showOnlyFavoritePairs: getShowOnlyFavoritePairsSetting(state),
     isCcyArticleAvailbale: Boolean(getActiveMarketCcyId(state)),
+    getCurrencySymbol: getCurrencySymbolMemo(state),
   }
 }
 

--- a/src/components/ExchangeInfoBar/ExchangeInfoBar.js
+++ b/src/components/ExchangeInfoBar/ExchangeInfoBar.js
@@ -38,8 +38,8 @@ const ExchangeInfoBar = ({
     const arrayWithFavorites = arrayWithPairs.filter(pair => object[pair])
     updateFavorites(authToken, arrayWithFavorites, currentMode)
   }
-  const onChangeMarketHandler = ({ rowData: { id } } = {}) => {
-    const newMarket = _find(markets, market => market.uiID === id)
+  const onChangeMarketHandler = ({ rowData } = {}) => {
+    const newMarket = _find(markets, market => market.uiID === rowData?.uiID)
     if (!newMarket) {
       return
     }

--- a/src/components/ExchangeInfoBar/ExchangeInfoBar.js
+++ b/src/components/ExchangeInfoBar/ExchangeInfoBar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { VOLUME_UNIT, VOLUME_UNIT_PAPER } from '@ufx-ui/bfx-containers'
 import { TickerList, Ticker } from '@ufx-ui/core'
@@ -6,7 +6,7 @@ import _find from 'lodash/find'
 
 import Panel from '../../ui/Panel'
 import useSize from '../../hooks/useSize'
-import { tickerDataMapping, rowMapping } from './ExchangeInforBar.constants'
+import { getTickerDataMapping, rowMapping } from './ExchangeInforBar.constants'
 
 import './style.css'
 import { MAIN_MODE } from '../../redux/reducers/ui'
@@ -29,6 +29,7 @@ const ExchangeInfoBar = ({
   updateShowOnlyFavoritePairs,
   showCcyIconModal,
   isCcyArticleAvailbale,
+  getCurrencySymbol,
 }) => {
   const [tickerRef, size] = useSize()
 
@@ -37,7 +38,7 @@ const ExchangeInfoBar = ({
     const arrayWithFavorites = arrayWithPairs.filter(pair => object[pair])
     updateFavorites(authToken, arrayWithFavorites, currentMode)
   }
-  const onChangeMarketHandler = ({ rowData: { id } }) => {
+  const onChangeMarketHandler = ({ rowData: { id } } = {}) => {
     const newMarket = _find(markets, market => market.uiID === id)
     if (!newMarket) {
       return
@@ -58,6 +59,8 @@ const ExchangeInfoBar = ({
     uiID,
     isPerp,
   } = activeMarket
+
+  const tickerMapping = useMemo(() => getTickerDataMapping(getCurrencySymbol), [getCurrencySymbol])
 
   return (
     <Panel
@@ -85,7 +88,7 @@ const ExchangeInfoBar = ({
               isPerp,
               perpUI: isPerp ? uiID : null,
             }}
-            dataMapping={tickerDataMapping}
+            dataMapping={tickerMapping}
             className='hfui-exchangeinfobar__ticker'
             volumeUnit={tickersVolumeUnit !== 'SELF' ? tickersVolumeUnit : quote}
             ccyIcon={<CCYIcon ccy={base} />}
@@ -147,6 +150,7 @@ ExchangeInfoBar.propTypes = {
   updateShowOnlyFavoritePairs: PropTypes.func.isRequired,
   showCcyIconModal: PropTypes.func.isRequired,
   isCcyArticleAvailbale: PropTypes.bool,
+  getCurrencySymbol: PropTypes.func.isRequired,
 }
 
 ExchangeInfoBar.defaultProps = {

--- a/src/components/ExchangeInfoBar/ExchangeInforBar.constants.js
+++ b/src/components/ExchangeInfoBar/ExchangeInforBar.constants.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { TICKERLIST_KEYS, TICKER_KEYS } from '@ufx-ui/core'
 import CCYIcon from './CCYIcon'
 
-export const tickerDataMapping = {
+export const getTickerDataMapping = (getCurrencySymbol) => ({
   [TICKER_KEYS.BASE_CCY]: {
     renderer: ({ baseCcy, quoteCcy, data }) => {
       const { isPerp, perpUI } = data
@@ -12,15 +12,15 @@ export const tickerDataMapping = {
       return (
         isPerp ? <div className='highlight'>{perpUI}</div> : (
           <>
-            <div className='highlight'>{baseCcy}</div>
+            <div className='highlight'>{getCurrencySymbol(baseCcy)}</div>
             /
-            <div className='quote-ccy'>{quoteCcy}</div>
+            <div className='quote-ccy'>{getCurrencySymbol(quoteCcy)}</div>
           </>
         )
       )
     },
   },
-}
+})
 
 export const rowMapping = {
   [TICKERLIST_KEYS.BASE_CCY]: {

--- a/src/components/ExchangeInfoBar/ExchangeInforBar.constants.js
+++ b/src/components/ExchangeInfoBar/ExchangeInforBar.constants.js
@@ -25,31 +25,17 @@ export const tickerDataMapping = {
 export const rowMapping = {
   [TICKERLIST_KEYS.BASE_CCY]: {
     renderer: (
-      { rowData },
+      { rowData = {} },
     ) => {
       const {
-        baseCcy, quoteCcy, isPerp, perpUI,
+        baseCcy, isPerp, perpUI, id,
       } = rowData
 
       return (
-        <>
-          {isPerp ? (
-            <span className='ccy-pair'>
-              <CCYIcon small ccy={baseCcy} />
-              <span>{perpUI}</span>
-            </span>
-          ) : (
-            <span className='ccy-pair'>
-              <CCYIcon small ccy={baseCcy} />
-              <span>
-                {baseCcy}
-                /
-                {quoteCcy}
-              </span>
-            </span>
-          )}
-        </>
-
+        <span className='ccy-pair'>
+          <CCYIcon small ccy={baseCcy} />
+          <span>{isPerp ? perpUI : id}</span>
+        </span>
       )
     },
   },

--- a/src/components/MarketSelect/MarketSelect.container.js
+++ b/src/components/MarketSelect/MarketSelect.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
 import WSActions from '../../redux/actions/ws'
 import { getAuthToken, getFavoritePairs } from '../../redux/selectors/ws'
@@ -9,6 +10,7 @@ const mapStateToProps = state => ({
   favoritePairs: getFavoritePairs(state),
   authToken: getAuthToken(state),
   currentMode: getCurrentMode(state),
+  getCurrencySymbol: reduxSelectors.getCurrencySymbolMemo(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/MarketSelect/MarketSelect.js
+++ b/src/components/MarketSelect/MarketSelect.js
@@ -13,6 +13,7 @@ import Dropdown from '../../ui/Dropdown'
 import FavoriteIcon from '../../ui/Icons/FavoriteIcon'
 
 import './style.css'
+import { getPairFromMarket } from '../../util/market'
 
 const MarketSelect = ({
   savePairs,
@@ -24,6 +25,7 @@ const MarketSelect = ({
   className,
   renderLabel,
   renderWithFavorites,
+  getCurrencySymbol,
   ...otherProps
 }) => {
   const [searchTerm, setSearchTerm] = useState('')
@@ -45,11 +47,11 @@ const MarketSelect = ({
         return _includes(matches, _toLower(searchTerm))
       }, []) : markets
     const options = _map(filtered, (m => ({
-      label: m.uiID || `${m.base}/${m.quote}`,
+      label: getPairFromMarket(m, getCurrencySymbol) || `${m.base}/${m.quote}`,
       value: m.uiID,
     })), [])
     return options.sort((a, b) => favoritePairs.includes(b.value) - favoritePairs.includes(a.value))
-  }, [searchTerm, favoritePairs])
+  }, [searchTerm, favoritePairs, getCurrencySymbol])
 
   return (
     <Dropdown
@@ -101,6 +103,7 @@ MarketSelect.propTypes = {
   authToken: PropTypes.string.isRequired,
   favoritePairs: PropTypes.instanceOf(Array),
   renderWithFavorites: PropTypes.bool,
+  getCurrencySymbol: PropTypes.func.isRequired,
 }
 
 MarketSelect.defaultProps = {

--- a/src/components/OrderBookPanel/OrderBookPanel.container.js
+++ b/src/components/OrderBookPanel/OrderBookPanel.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import {
   getActiveMarket, getComponentState, getMarketComponents,
 } from '../../redux/selectors/ui'
@@ -19,6 +20,7 @@ const mapStateToProps = (state = {}, ownProps = {}) => {
     markets: getMarkets(state),
     isTradingTerminal,
     allMarketBooks: getMarketComponents(state, 'book'),
+    getCurrencySymbol: reduxSelectors.getCurrencySymbolMemo(state),
   }
 }
 

--- a/src/components/OrderBookPanel/OrderBookPanel.js
+++ b/src/components/OrderBookPanel/OrderBookPanel.js
@@ -18,6 +18,7 @@ import PanelSettings from '../../ui/PanelSettings'
 import Panel from '../../ui/Panel'
 
 import './style.css'
+import { getPairFromMarket } from '../../util/market'
 
 const { WSSubscribeChannel, WSUnsubscribeChannel } = reduxActions
 const { SUBSCRIPTION_CONFIG } = reduxConstants
@@ -36,7 +37,7 @@ const OrderBookPanel = (props) => {
   const {
     onRemove, showMarket, canChangeStacked, moveable,
     removeable, dark, savedState, activeMarket,
-    markets, canChangeMarket, layoutID, layoutI, updateState, isTradingTerminal, allMarketBooks,
+    markets, canChangeMarket, layoutID, layoutI, updateState, isTradingTerminal, allMarketBooks, getCurrencySymbol,
   } = props
   const {
     sumAmounts = true,
@@ -45,6 +46,7 @@ const OrderBookPanel = (props) => {
   } = savedState
   const bookMarket = isTradingTerminal ? activeMarket : currentMarket
   const { base, quote } = bookMarket
+  const currentPair = getPairFromMarket(activeMarket, getCurrencySymbol)
 
   const [settingsOpen, setSettingsOpen] = useState(false)
 
@@ -145,7 +147,7 @@ const OrderBookPanel = (props) => {
       secondaryHeaderComponents={
         showMarket && canChangeMarket && renderMarketDropdown()
       }
-      headerComponents={showMarket && !canChangeMarket && <p>{activeMarket.uiID}</p>}
+      headerComponents={showMarket && !canChangeMarket && <p>{currentPair}</p>}
       settingsOpen={settingsOpen}
       onToggleSettings={onToggleSettings}
       className='hfui-book__wrapper'
@@ -212,6 +214,7 @@ OrderBookPanel.propTypes = {
   updateState: PropTypes.func.isRequired,
   isTradingTerminal: PropTypes.bool,
   allMarketBooks: PropTypes.arrayOf(PropTypes.object),
+  getCurrencySymbol: PropTypes.func.isRequired,
 }
 
 OrderBookPanel.defaultProps = {

--- a/src/components/TradesTablePanel/TradesTablePanel.container.js
+++ b/src/components/TradesTablePanel/TradesTablePanel.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import UIActions from '../../redux/actions/ui'
 import { getMarkets } from '../../redux/selectors/meta'
 import { getAuthToken } from '../../redux/selectors/ws'
@@ -15,6 +16,7 @@ const mapStateToProps = (state = {}, { layoutID, layoutI: id } = {}) => ({
   authToken: getAuthToken(state),
   activeMarket: getActiveMarket(state),
   savedState: getComponentState(state, layoutID, 'trades', id),
+  getCurrencySymbol: reduxSelectors.getCurrencySymbolMemo(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/TradesTablePanel/TradesTablePanel.js
+++ b/src/components/TradesTablePanel/TradesTablePanel.js
@@ -14,6 +14,7 @@ import {
 import MarketSelect from '../MarketSelect'
 import Panel from '../../ui/Panel'
 import './style.css'
+import { getPairFromMarket } from '../../util/market'
 
 const { trades } = reduxConstants
 const { SUBSCRIPTION_CONFIG } = trades
@@ -35,10 +36,12 @@ const TradesTablePanel = (props) => {
     activeMarket,
     canChangeMarket,
     allMarketTrades,
+    getCurrencySymbol,
   } = props
 
   const { currentMarket = activeMarket } = savedState
   const { base, quote } = currentMarket
+  const currentPair = getPairFromMarket(activeMarket, getCurrencySymbol)
 
   const { symbol, dispatch, isWSConnected } = useCommonBfxData(base, quote)
   const marketData = useSelector(state => getRecentTrades(state, symbol))
@@ -113,7 +116,7 @@ const TradesTablePanel = (props) => {
       secondaryHeaderComponents={
         showMarket && canChangeMarket && renderMarketDropdown()
       }
-      headerComponents={showMarket && !canChangeMarket && <p>{activeMarket.uiID}</p>}
+      headerComponents={showMarket && !canChangeMarket && <p>{currentPair}</p>}
     >
       <Trades
         market={marketData}
@@ -145,6 +148,7 @@ TradesTablePanel.propTypes = {
   activeMarket: PropTypes.shape({
     uiID: PropTypes.string,
   }).isRequired,
+  getCurrencySymbol: PropTypes.func.isRequired,
 }
 
 TradesTablePanel.defaultProps = {

--- a/src/redux/selectors/ao/get_active_algo_orders.js
+++ b/src/redux/selectors/ao/get_active_algo_orders.js
@@ -1,8 +1,13 @@
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import { createSelector } from 'reselect'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
+
+import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
 import { getMarkets } from '../meta'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.AOS
 
@@ -10,11 +15,17 @@ const activeAlgoOrders = (state) => {
   return _get(state, `${path}.activeAlgoOrders`, [])
 }
 
-const activeAlgoOrdersWithReplacedPairs = createSelector([getMarkets, activeAlgoOrders], (markets, orders) => {
+const activeAlgoOrdersWithReplacedPairs = createSelector([getMarkets, activeAlgoOrders, getCurrencySymbolMemo], (markets, orders, getCurrencySymbol) => {
   return _map(orders, (order) => {
-    const { symbol } = order.args
-    const currentMarket = markets[symbol]
-    return { ...order, args: { ...order.args, symbol: currentMarket.uiID } }
+    const currentMarket = markets[order?.args?.symbol]
+
+    return {
+      ...order,
+      args: {
+        ...order.args,
+        symbol: getPairFromMarket(currentMarket, getCurrencySymbol),
+      },
+    }
   }, [])
 })
 

--- a/src/redux/selectors/meta/get_tickers_array.js
+++ b/src/redux/selectors/meta/get_tickers_array.js
@@ -8,18 +8,18 @@ import { reduxSelectors, prepareTickers } from '@ufx-ui/bfx-containers'
 import getMarkets from './get_markets'
 import getTickersKeys from './get_tickers_keys'
 import { getTickersVolumeUnit } from '../ui'
+import { getPairFromMarket } from '../../../util/market'
 
-const tickersSelector = state => reduxSelectors.getTickers(state)
-const getCurrencySymbol = state => reduxSelectors.getCurrencySymbolMemo(state)
-const tickersVolumeUnit = state => getTickersVolumeUnit(state)
+const { getCurrencySymbolMemo, getTickers } = reduxSelectors
 
-const getTickersInfo = createSelector([tickersSelector, getMarkets], (tickers, markets) => {
+const getTickersInfo = createSelector([getTickers, getMarkets, getCurrencySymbolMemo], (tickers, markets, getCurrencySymbol) => {
   const fullTickersData = _reduce(markets, (acc, market) => {
     const {
       wsID, base, quote, uiID, ccyLabels, isPerp,
     } = market
+    const id = getPairFromMarket(market, getCurrencySymbol)
     const newTickerObject = {
-      id: uiID,
+      id,
       baseCcy: base,
       quoteCcy: quote,
       changePerc: _get(tickers, `${wsID}.changePerc`, 0),
@@ -42,15 +42,15 @@ const preparedTickersArray = createSelector(
   [
     getTickersInfo,
     getTickersKeys,
-    tickersSelector,
-    getCurrencySymbol,
-    tickersVolumeUnit,
+    getTickers,
+    getCurrencySymbolMemo,
+    getTickersVolumeUnit,
   ],
-  (tickersInfo, tickersKeys, tickers, _getCurrencySymbol, _tickersVolumeUnit) => {
+  (tickersInfo, tickersKeys, tickers, getCurrencySymbol, tickersVolumeUnit) => {
     if (_isEmpty(tickersInfo)) {
       return []
     }
-    const prepared = prepareTickers(tickersKeys, tickers, _tickersVolumeUnit, _getCurrencySymbol)
+    const prepared = prepareTickers(tickersKeys, tickers, tickersVolumeUnit, getCurrencySymbol)
 
     return _map(tickersKeys, (pair) => {
       const ticker = tickersInfo[pair]

--- a/src/redux/selectors/meta/get_tickers_array.js
+++ b/src/redux/selectors/meta/get_tickers_array.js
@@ -20,6 +20,7 @@ const getTickersInfo = createSelector([getTickers, getMarkets, getCurrencySymbol
     const id = getPairFromMarket(market, getCurrencySymbol)
     const newTickerObject = {
       id,
+      uiID,
       baseCcy: base,
       quoteCcy: quote,
       changePerc: _get(tickers, `${wsID}.changePerc`, 0),

--- a/src/redux/selectors/ws/get_algo_orders.js
+++ b/src/redux/selectors/ws/get_algo_orders.js
@@ -1,8 +1,13 @@
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import { createSelector } from 'reselect'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
+
+import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
 import { getMarkets } from '../meta'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
@@ -10,11 +15,17 @@ const algoOrders = (state) => {
   return _get(state, `${path}.algoOrders`, [])
 }
 
-const algoOrdersWithReplacedPairs = createSelector([getMarkets, algoOrders], (markets, orders) => {
+const algoOrdersWithReplacedPairs = createSelector([getMarkets, algoOrders, getCurrencySymbolMemo], (markets, orders, getCurrencySymbol) => {
   return _map(orders, (order) => {
-    const { symbol } = order.args
-    const currentMarket = markets[symbol]
-    return { ...order, args: { ...order.args, uiID: currentMarket.uiID } }
+    const currentMarket = markets[order?.args?.symbol]
+
+    return {
+      ...order,
+      args: {
+        ...order.args,
+        uiID: getPairFromMarket(currentMarket, getCurrencySymbol),
+      },
+    }
   }, [])
 })
 

--- a/src/redux/selectors/ws/get_all_positions.js
+++ b/src/redux/selectors/ws/get_all_positions.js
@@ -1,8 +1,13 @@
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import { createSelector } from 'reselect'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
+
+import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
 import { getMarkets } from '../meta'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
@@ -12,11 +17,14 @@ const allPositions = (state) => {
   return _get(state, `${path}.positions`, EMPTY_ARR)
 }
 
-const positionWithReplacedPairs = createSelector([getMarkets, allPositions], (markets, positions) => {
+const positionWithReplacedPairs = createSelector([getMarkets, allPositions, getCurrencySymbolMemo], (markets, positions, getCurrencySymbol) => {
   return _map(positions, (position) => {
-    const { symbol } = position
-    const currentMarket = markets[symbol]
-    return { ...position, uiID: currentMarket.uiID }
+    const currentMarket = markets?.[position?.symbol]
+
+    return {
+      ...position,
+      uiID: getPairFromMarket(currentMarket, getCurrencySymbol),
+    }
   }, [])
 })
 

--- a/src/redux/selectors/ws/get_atomic_orders.js
+++ b/src/redux/selectors/ws/get_atomic_orders.js
@@ -1,8 +1,12 @@
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import { createSelector } from 'reselect'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import { REDUCER_PATHS } from '../../config'
 import { getMarkets } from '../meta'
+import { getPairFromMarket } from '../../../util/market'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
@@ -10,11 +14,14 @@ const atomicOrders = (state) => {
   return _get(state, `${path}.orders`, [])
 }
 
-const atomicOrdersWithReplacedPairs = createSelector([getMarkets, atomicOrders], (markets, orders) => {
+const atomicOrdersWithReplacedPairs = createSelector([getMarkets, atomicOrders, getCurrencySymbolMemo], (markets, orders, getCurrencySymbol) => {
   return _map(orders, (order) => {
-    const { symbol } = order
-    const currentMarket = markets[symbol]
-    return { ...order, uiID: currentMarket.uiID }
+    const currentMarket = markets?.[order?.symbol]
+
+    return {
+      ...order,
+      uiID: getPairFromMarket(currentMarket, getCurrencySymbol),
+    }
   }, [])
 })
 

--- a/src/redux/selectors/ws/get_order_history.js
+++ b/src/redux/selectors/ws/get_order_history.js
@@ -1,8 +1,12 @@
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import { createSelector } from 'reselect'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
+import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
 import { getMarkets } from '../meta'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
@@ -10,11 +14,14 @@ const orderHistory = (state) => {
   return _get(state, `${path}.orderHistory`, [])
 }
 
-const orderHistoryWithReplacedPairs = createSelector([getMarkets, orderHistory], (markets, orders) => {
+const orderHistoryWithReplacedPairs = createSelector([getMarkets, orderHistory, getCurrencySymbolMemo], (markets, orders, getCurrencySymbol) => {
   return _map(orders, (order) => {
-    const { symbol } = order
-    const currentMarket = markets[symbol]
-    return { ...order, symbol: currentMarket.uiID }
+    const currentMarket = markets?.[order?.symbol]
+
+    return {
+      ...order,
+      symbol: getPairFromMarket(currentMarket, getCurrencySymbol),
+    }
   }, [])
 })
 

--- a/src/util/market.js
+++ b/src/util/market.js
@@ -3,3 +3,5 @@ import _first from 'lodash/first'
 import _get from 'lodash/get'
 
 export const getDefaultMarket = (markets) => _get(markets, [_first(_keys(markets))], 'uiID')
+
+export const getPairFromMarket = (market, getCurrencySymbol) => `${getCurrencySymbol(market?.base)}/${getCurrencySymbol(market?.quote)}`


### PR DESCRIPTION
Description: shows currency based on mapping from https://api.bitfinex.com/v2/conf/pub:map:currency:sym
i.e. UST -> USDt, IOT -> IOTA