### PR TITLE
(improvement) Added OrderForm conneting modal & fixed overlap

### DIFF
--- a/src/components/OrderForm/Modals/ConnectingModal/ConnectingModal.js
+++ b/src/components/OrderForm/Modals/ConnectingModal/ConnectingModal.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import OrderFormModal from '../../OrderFormModal'
+
+const ConnectingModal = () => (
+  <OrderFormModal
+    title='CONNECTING'
+    icon='icon-api'
+    content={(
+      <span>
+        Please wait while connecting to the API server..
+      </span>
+    )}
+  />
+)
+
+export default ConnectingModal

--- a/src/components/OrderForm/Modals/ConnectingModal/index.js
+++ b/src/components/OrderForm/Modals/ConnectingModal/index.js
@@ -1,0 +1,3 @@
+import ConnectingModal from './ConnectingModal'
+
+export default ConnectingModal

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -377,7 +377,7 @@ class OrderForm extends React.Component {
 
     const apiClientConnected = apiClientState === 2
     const apiClientConnecting = apiClientState === 1
-    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid && apiCredentials?.sufficientPermissions
+    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid
     const isConnectedWithValidAPI = apiClientConnected && apiClientConfigured
     const showOrderform = isConnectedWithValidAPI || !isElectronApp
     const renderData = marketToQuoteBase(currentMarket)

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -26,6 +26,7 @@ import timeFrames from '../../util/time_frames'
 
 import Panel from '../../ui/Panel'
 
+import ConnectingModal from './Modals/ConnectingModal'
 import UnconfiguredModal from './Modals/UnconfiguredModal'
 import SubmitAPIKeysModal from './Modals/SubmitAPIKeysModal'
 import OrderFormMenu from './OrderFormMenu'
@@ -376,7 +377,7 @@ class OrderForm extends React.Component {
 
     const apiClientConnected = apiClientState === 2
     const apiClientConnecting = apiClientState === 1
-    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid
+    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid // && apiCredentials?.sufficientPermissions
     const isConnectedWithValidAPI = apiClientConnected && apiClientConfigured
     const showOrderform = isConnectedWithValidAPI || !isElectronApp
     const renderData = marketToQuoteBase(currentMarket)
@@ -419,7 +420,11 @@ class OrderForm extends React.Component {
         >
           <div key='orderform-wrapper' className='hfui-orderform__wrapper'>
             {isElectronApp && [
-              !isConnectedWithValidAPI && !configureModalOpen && (
+              apiClientConnecting && (
+                <ConnectingModal key='connecting' />
+              ),
+
+              !apiClientConfigured && !configureModalOpen && (
                 <UnconfiguredModal
                   key='unconfigured'
                   onClick={this.onToggleConfigureModal}
@@ -428,7 +433,7 @@ class OrderForm extends React.Component {
                 />
               ),
 
-              !isConnectedWithValidAPI && configureModalOpen && (
+              !apiClientConfigured && configureModalOpen && (
                 <SubmitAPIKeysModal
                   key='submit-api-keys'
                   onClose={this.onToggleConfigureModal}
@@ -439,7 +444,7 @@ class OrderForm extends React.Component {
               ),
             ]}
 
-            {helpOpen && currentLayout && currentLayout.customHelp && (
+            {helpOpen && showOrderform && currentLayout && currentLayout.customHelp && (
               <div key='overlay-wrapper' className='hfui-orderform__overlay-wrapper'>
                 <div className='hfui-orderform__help-inner'>
                   <p className='hfui-orderform__help-title'>
@@ -469,7 +474,7 @@ class OrderForm extends React.Component {
               </div>
             )}
 
-            {!helpOpen && currentLayout && [
+            {!helpOpen && currentLayout && showOrderform && [
               <div className='hfui-orderform__layout-label' key='layout-label'>
                 <i
                   className='icon-back-arrow'

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -377,7 +377,7 @@ class OrderForm extends React.Component {
 
     const apiClientConnected = apiClientState === 2
     const apiClientConnecting = apiClientState === 1
-    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid // && apiCredentials?.sufficientPermissions
+    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid && apiCredentials?.sufficientPermissions
     const isConnectedWithValidAPI = apiClientConnected && apiClientConfigured
     const showOrderform = isConnectedWithValidAPI || !isElectronApp
     const renderData = marketToQuoteBase(currentMarket)


### PR DESCRIPTION
ASANA Ticket: [[bug] Overlap of "disconnected modal" and order form](https://app.asana.com/0/1125859137800433/1201017008819470/f)
Issue: bitfinexcom/bfx-hf-ui#592

**As Bhoomi proposed, before merging the PR a new `sufficientPermissions` key should be added to the `data.api_credentials.validation` response.**

 - Added 'Connecting' modal which indicates the API client connection state instead of showing fake 'Unconfigured' modal
 - Fixed OrderForm overlap by adding `showOrderform` check

![Screenshot from 2021-09-21 13-52-34](https://user-images.githubusercontent.com/35810911/134158693-b8a9ccbc-f6e3-4b49-85b1-1cc8621c65f4.png)


