### PR TITLE
(improvement) statusbar layout change

### DIFF
--- a/src/components/StatusBar/StatusBar.js
+++ b/src/components/StatusBar/StatusBar.js
@@ -37,38 +37,33 @@ const StatusBar = ({
             v
             {appVersion}
           </p>
-
-          <p>
-            {apiClientConnected ? 'UNLOCKED' : 'LOCKED'}
-          </p>
         </div>
       )}
 
       <div className='hfui-statusbar__right'>
         {isElectronApp && (
           <>
-            <p>
-              {apiClientConnected && 'HF Connected'}
-              {apiClientConnecting && 'HF Connecting'}
-              {apiClientDisconnected && 'HF Disconnected'}
-            </p>
-
             <span className={ClassNames('hfui-statusbar__statuscircle', {
               green: apiClientConnected,
               yellow: apiClientConnecting,
               red: apiClientDisconnected,
             })}
             />
+            <p>
+              {apiClientConnected && 'HF Connected'}
+              {apiClientConnecting && 'HF Connecting'}
+              {apiClientDisconnected && 'HF Disconnected'}
+            </p>
+            <div className='hfui-statusbar__divide' />
           </>
         )}
-
-        <p>{(wsConnected && !wsConnInterrupted) ? 'WS Connected' : 'WS Disconnected'}</p>
 
         <span className={ClassNames('hfui-statusbar__statuscircle', {
           green: wsConnected && !wsConnInterrupted,
           red: !wsConnected || wsConnInterrupted,
         })}
         />
+        <p>{(wsConnected && !wsConnInterrupted) ? 'WS Connected' : 'WS Disconnected'}</p>
       </div>
     </div>
   )

--- a/src/components/StatusBar/style.scss
+++ b/src/components/StatusBar/style.scss
@@ -55,6 +55,10 @@
     vertical-align: middle;
     margin-right: 10px;
   }
+
+  & > *:last-child {
+    margin-right: 0;
+  }
 }
 
 .hfui-statusbar__statuscircle {
@@ -62,6 +66,7 @@
   height: 8px;
   border-radius: 50%;
   display: inline-block;
+  margin-right: 8px;
 
   &.green {
     background: $green-color;
@@ -78,4 +83,9 @@
 
 .hfui-statusbar__version {
   line-height: 32px;
+}
+
+.hfui-statusbar__divide {
+  border-left: 1px solid $lighter-background-color;
+  height: 60%;
 }


### PR DESCRIPTION
ASANA Ticket: [[improvement] left-align Statusbar connectivity icons as it's done on the bitfinex.com website](https://app.asana.com/0/1125859137800433/1201044602934732/f)

Description:
 - left-aligned HF Connected and WS Connected status icons as it's done on bitfinex.com website
 - removed LOCKED/UNLOCKED indicator as it can be known via the 'HF Connected' state

UI Demonstration:
![Screenshot from 2021-09-23 17-31-27](https://user-images.githubusercontent.com/35810911/134526682-b0bc8267-e22b-4cb0-9061-b47ed0140a7c.png)

