### PR TITLE
(refactor) rendering improvements, redux state optimisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
   },
   "dependencies": {
     "@projectstorm/react-diagrams": "^5.3.2",
-    "@ufx-ui/bfx-containers": "0.10.9",
-    "@ufx-ui/core": "0.10.8",
+    "@ufx-ui/bfx-containers": "0.10.11",
+    "@ufx-ui/core": "0.10.11",
     "axios": "^0.21.1",
     "bfx-api-node-models": "^1.4.1",
     "bfx-api-node-util": "^1.0.10",

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { defaultCellRenderer } from '../../util/ui'
 
-export default (authToken, cancelOrder, gaCancelOrder, t) => [{
+export default (authToken, cancelOrder, gaCancelOrder, t, getMarketPair) => [{
   label: t('table.name'),
   dataKey: 'name',
   width: 90,
@@ -25,7 +25,7 @@ export default (authToken, cancelOrder, gaCancelOrder, t) => [{
   dataKey: 'args.symbol',
   width: 140,
   flexGrow: 1.4,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.args?.uiID),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(getMarketPair(rowData.args?.symbol)),
 }, {
   label: t('table.label'),
   dataKey: 'label',

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.container.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.container.js
@@ -6,6 +6,7 @@ import { getActiveMarket } from '../../redux/selectors/ui'
 import WSActions from '../../redux/actions/ws'
 import GAActions from '../../redux/actions/google_analytics'
 import AlgoOrdersTable from './AlgoOrdersTable'
+import { getMarketPair } from '../../redux/selectors/meta'
 
 const debug = Debug('hfui:c:algo-orders-table')
 
@@ -14,6 +15,7 @@ const mapStateToProps = (state = {}, { activeFilter }) => ({
   algoOrders: getAlgoOrders(state),
   filteredAlgoOrders: getFilteredAlgoOrders(state)(activeFilter),
   activeMarket: getActiveMarket(state),
+  getMarketPair: getMarketPair(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.js
@@ -8,7 +8,7 @@ import AlgoOrdersTableColumns from './AlgoOrdersTable.columns'
 import './style.css'
 
 const AlgoOrdersTable = ({
-  filteredAlgoOrders, algoOrders, cancelOrder, authToken, gaCancelOrder, renderedInTradingState,
+  filteredAlgoOrders, algoOrders, cancelOrder, authToken, gaCancelOrder, renderedInTradingState, getMarketPair,
 }) => {
   const data = renderedInTradingState ? filteredAlgoOrders : algoOrders
   const { t } = useTranslation()
@@ -20,7 +20,7 @@ const AlgoOrdersTable = ({
       ) : (
         <VirtualTable
           data={data}
-          columns={AlgoOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, t)}
+          columns={AlgoOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, t, getMarketPair)}
           defaultSortBy='gid'
           defaultSortDirection='ASC'
           rowHeight={30}
@@ -31,17 +31,18 @@ const AlgoOrdersTable = ({
 }
 
 AlgoOrdersTable.propTypes = {
-  algoOrders: PropTypes.arrayOf(PropTypes.object),
-  filteredAlgoOrders: PropTypes.arrayOf(PropTypes.object),
+  algoOrders: PropTypes.objectOf(PropTypes.object),
+  filteredAlgoOrders: PropTypes.objectOf(PropTypes.object),
   cancelOrder: PropTypes.func.isRequired,
   gaCancelOrder: PropTypes.func.isRequired,
   authToken: PropTypes.string.isRequired,
   renderedInTradingState: PropTypes.bool,
+  getMarketPair: PropTypes.func.isRequired,
 }
 
 AlgoOrdersTable.defaultProps = {
-  algoOrders: [],
-  filteredAlgoOrders: [],
+  algoOrders: {},
+  filteredAlgoOrders: {},
   renderedInTradingState: false,
 }
 

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -11,7 +11,7 @@ const STYLES = {
   price: { justifyContent: 'flex-end' },
 }
 
-export default (authToken, cancelOrder, gaCancelOrder, { width }, t) => [{
+export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPair) => [{
   label: '',
   dataKey: '',
   width: 15,
@@ -25,7 +25,7 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t) => [{
   dataKey: 'symbol',
   width: 135,
   flexGrow: 1.35,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.uiID),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(getMarketPair(rowData.symbol)),
 }, {
   label: t('table.type'),
   dataKey: 'type',

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.container.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.container.js
@@ -6,6 +6,7 @@ import WSActions from '../../redux/actions/ws'
 import GAActions from '../../redux/actions/google_analytics'
 
 import AtomicOrdersTable from './AtomicOrdersTable'
+import { getMarketPair } from '../../redux/selectors/meta'
 
 const debug = Debug('hfui:c:atomic-orders-table')
 
@@ -13,6 +14,7 @@ const mapStateToProps = (state = {}, { activeFilter }) => ({
   authToken: getAuthToken(state),
   filteredAtomicOrders: getFilteredAtomicOrders(state)(activeFilter),
   atomicOrders: getAtomicOrders(state),
+  getMarketPair: getMarketPair(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -23,8 +23,8 @@ const AtomicOrdersTable = ({
         <VirtualTable
           data={data}
           columns={AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t)}
-          defaultSortBy='id'
-          defaultSortDirection='ASC'
+          defaultSortBy='created'
+          defaultSortDirection='DESC'
         />
       )}
     </div>

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import { VirtualTable } from '@ufx-ui/core'
@@ -9,11 +9,16 @@ import AtomicOrdersTableColumns from './AtomicOrdersTable.columns'
 import './style.css'
 
 const AtomicOrdersTable = ({
-  atomicOrders, filteredAtomicOrders, renderedInTradingState, cancelOrder, authToken, gaCancelOrder,
+  atomicOrders, filteredAtomicOrders, renderedInTradingState,
+  cancelOrder, authToken, gaCancelOrder, getMarketPair,
 }) => {
   const [ref, size] = useSize()
   const data = renderedInTradingState ? filteredAtomicOrders : atomicOrders
   const { t } = useTranslation()
+  const columns = useMemo(
+    () => AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t, getMarketPair),
+    [authToken, cancelOrder, gaCancelOrder, getMarketPair, size, t],
+  )
 
   return (
     <div ref={ref} className='hfui-orderstable__wrapper'>
@@ -22,7 +27,7 @@ const AtomicOrdersTable = ({
       ) : (
         <VirtualTable
           data={data}
-          columns={AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t)}
+          columns={columns}
           defaultSortBy='created'
           defaultSortDirection='DESC'
         />
@@ -33,8 +38,9 @@ const AtomicOrdersTable = ({
 
 AtomicOrdersTable.propTypes = {
   authToken: PropTypes.string.isRequired,
-  atomicOrders: PropTypes.arrayOf(PropTypes.object),
-  filteredAtomicOrders: PropTypes.arrayOf(PropTypes.object),
+  atomicOrders: PropTypes.objectOf(PropTypes.object),
+  filteredAtomicOrders: PropTypes.objectOf(PropTypes.object),
+  getMarketPair: PropTypes.func.isRequired,
   cancelOrder: PropTypes.func.isRequired,
   gaCancelOrder: PropTypes.func.isRequired,
   renderedInTradingState: PropTypes.bool,

--- a/src/components/BalancesTable/BalancesTable.js
+++ b/src/components/BalancesTable/BalancesTable.js
@@ -42,15 +42,15 @@ const BalancesTable = ({
 }
 
 BalancesTable.propTypes = {
-  balances: PropTypes.arrayOf(PropTypes.object),
-  filteredBalances: PropTypes.arrayOf(PropTypes.object),
+  balances: PropTypes.objectOf(PropTypes.object),
+  filteredBalances: PropTypes.objectOf(PropTypes.object),
   renderedInTradingState: PropTypes.bool,
   hideZeroBalances: PropTypes.bool,
 }
 
 BalancesTable.defaultProps = {
-  balances: [],
-  filteredBalances: [],
+  balances: {},
+  filteredBalances: {},
   renderedInTradingState: false,
   hideZeroBalances: true,
 }

--- a/src/components/NotificationsSidebar/NotificationsSidebar.js
+++ b/src/components/NotificationsSidebar/NotificationsSidebar.js
@@ -1,12 +1,12 @@
-import React from 'react'
-import { Notifications } from '@ufx-ui/core'
+import React, {
+  memo, useState, useEffect, useCallback,
+} from 'react'
+import { Notifications, useInterval } from '@ufx-ui/core'
 import ClassNames from 'classnames'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import _map from 'lodash/map'
-import _includes from 'lodash/includes'
 import _filter from 'lodash/filter'
-import { nonce } from 'bfx-api-node-util'
 import { withTranslation } from 'react-i18next'
 
 import Panel from '../../ui/Panel'
@@ -14,68 +14,16 @@ import Button from '../../ui/Button'
 import Scrollbars from '../../ui/Scrollbars'
 import './style.css'
 
-const LIVE_NOTIFICATION_LIFETIME_MS = 5000
+const REFRESH_NOTIFICATIONS_MS = 1000
+const LIVE_NOTIFICATIONS_MS = 5000
 
-class NotificationsSidebar extends React.PureComponent {
-  state = {
-    lastShownMTS: 0,
-    liveNotifications: [],
-    shownNotifications: [],
-  }
+const NotificationsSidebar = (props) => {
+  const {
+    notifications, notificationsVisible, closeNotificationPanel, removeNotifications, clearNotifications, t,
+  } = props
+  const [newNotifications, setNewNotifications] = useState([])
 
-  constructor(props) {
-    super(props)
-
-    this.onClose = this.onClose.bind(this)
-    this.onClearNotifications = this.onClearNotifications.bind(this)
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const { notifications = [], t } = nextProps
-    const { shownNotifications } = prevState
-
-    if (notifications.length <= shownNotifications.length) {
-      return {}
-    }
-
-    const showMTS = Date.now()
-
-    return {
-      lastShownMTS: showMTS,
-      liveNotifications: [
-        // TODO: rework notifications state
-        // eslint-disable-next-line lodash/prefer-lodash-method
-        ...notifications.filter(({ cid }) => !_includes(shownNotifications, cid)).map(n => ({
-          n: {
-            message: n.i18n ? t(n.i18n.key, n.i18n.props) : n.text,
-            level: n.status,
-            ...n,
-          },
-          showMTS,
-          id: nonce(),
-        })),
-
-        ...prevState.liveNotifications,
-      ],
-      shownNotifications: _map(notifications, ({ cid }) => cid),
-    }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const { liveNotifications, lastShownMTS } = this.state
-
-    if (liveNotifications.length === prevState.liveNotifications.length) {
-      return
-    }
-
-    setTimeout(
-      this.timeoutLiveNotifications.bind(this, lastShownMTS),
-      LIVE_NOTIFICATION_LIFETIME_MS,
-    )
-  }
-
-  onClose({ cid, group }) {
-    const { removeNotifications } = this.props
+  const onClose = useCallback(({ cid, group }) => {
     let cids = []
 
     if (!_isEmpty(group)) {
@@ -84,80 +32,71 @@ class NotificationsSidebar extends React.PureComponent {
       cids = [cid]
     }
 
-    this.setState(({ shownNotifications }) => ({
-      shownNotifications: _filter(shownNotifications, n => !_includes(cids, n.cid)),
-    }))
     removeNotifications(cids)
-  }
+  },
+  [removeNotifications])
 
-  onClearNotifications() {
-    const { clearNotifications } = this.props
+  const onClearNotifications = () => {
     clearNotifications()
 
-    setTimeout(() => {
-      this.setState({
-        shownNotifications: [],
-      })
-    }, 1000)
+    setNewNotifications([])
   }
 
-  timeoutLiveNotifications(shownMTS) {
-    this.setState(({ liveNotifications }) => ({
-      liveNotifications: _filter(liveNotifications, ({ showMTS }) => showMTS !== shownMTS),
-    }))
+  const checkNotificationsTime = () => {
+    const nextNotifications = _filter(notifications, n => n?.mts > new Date().getTime() - LIVE_NOTIFICATIONS_MS)
+
+    setNewNotifications(nextNotifications)
   }
 
-  render() {
-    const { liveNotifications } = this.state
-    const {
-      notifications, notificationsVisible, closeNotificationPanel, t,
-    } = this.props
+  // set notification on component mount
+  useEffect(() => {
+    setNewNotifications(notifications)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-    return (
-      <>
-        <div className={ClassNames('hfui-notificationssidebar__wrapper', {
-          visible: notificationsVisible,
-          hidden: !notificationsVisible,
-        })}
+  // get notifications prop update with delay
+  useInterval(() => checkNotificationsTime(), REFRESH_NOTIFICATIONS_MS)
+
+  return (
+    <>
+      <div className={ClassNames('hfui-notificationssidebar__wrapper', {
+        visible: notificationsVisible,
+        hidden: !notificationsVisible,
+      })}
+      >
+        <Panel
+          label={t('notifications.title')}
+          hideIcons
+          closePanel={closeNotificationPanel}
+          preHeaderComponents={[
+            <Button
+              onClick={onClearNotifications}
+              key='clear-btn'
+              disabled={_isEmpty(notifications)}
+              className='hfui-notificationssidebar__header-btn'
+              label={[
+                <i key='icon' className='icon-clear' />,
+                <p key='text'>{t('notifications.clearAllBtn')}</p>,
+              ]}
+            />,
+          ]}
         >
-          <Panel
-            label={t('notifications.title')}
-            hideIcons
-            closePanel={closeNotificationPanel}
-            preHeaderComponents={[
-              <Button
-                onClick={this.onClearNotifications}
-                key='clear-btn'
-                disabled={_isEmpty(notifications)}
-                className='hfui-notificationssidebar__header-btn'
-                label={[
-                  <i key='icon' className='icon-clear' />,
-                  <p key='text'>{t('notifications.clearAllBtn')}</p>,
-                ]}
-              />,
-            ]}
-          >
-            {_isEmpty(notifications) ? (
-              <p className='hfui-notificationssidebar__empty'>{t('notifications.noNotifications')}</p>
-            ) : (
-              <Scrollbars>
-                <Notifications
-                  className='hfui-sidebar-notifications'
-                  notifications={_map(notifications, item => ({
-                    ...item,
-                    level: item.status,
-                    message: item.i18n ? t(item.i18n.key, item.i18n.props) : item.text,
-                  }))}
-                  onClose={this.onClose}
-                />
-              </Scrollbars>
-            )}
-          </Panel>
-        </div>
-        <Notifications className='hfui-notificationssidebar__external' notifications={_map(liveNotifications, item => item.n)} />
-      </>
-    )
-  }
+          {_isEmpty(notifications) ? (
+            <p className='hfui-notificationssidebar__empty'>{t('notifications.noNotifications')}</p>
+          ) : (
+            <Scrollbars>
+              <Notifications
+                className='hfui-sidebar-notifications'
+                notifications={notifications}
+                onClose={onClose}
+              />
+            </Scrollbars>
+          )}
+        </Panel>
+      </div>
+      <Notifications className='hfui-notificationssidebar__external' notifications={newNotifications} />
+    </>
+  )
 }
 
 NotificationsSidebar.propTypes = {
@@ -173,4 +112,4 @@ NotificationsSidebar.defaultProps = {
   notificationsVisible: false,
 }
 
-export default withTranslation()(NotificationsSidebar)
+export default withTranslation()(memo(NotificationsSidebar))

--- a/src/components/OrderHistory/OrderHistory.colunms.js
+++ b/src/components/OrderHistory/OrderHistory.colunms.js
@@ -17,7 +17,7 @@ const {
   STATUS,
 } = ORDER_HISTORY_KEYS
 
-export const ROW_MAPPING = {
+export const getRowMapping = (getMarketPair) => ({
   [ID]: {
     index: 0,
   },
@@ -26,7 +26,7 @@ export const ROW_MAPPING = {
   },
   [PAIR]: {
     index: 1,
-    format: (value, _, data) => _get(data, 'symbol'),
+    format: (value, _, data) => getMarketPair(_get(data, 'symbol')),
   },
   [AMOUNT]: {
     index: 2,
@@ -93,4 +93,4 @@ export const ROW_MAPPING = {
       return <FullDate ts={_get(data, 'created')} />
     },
   },
-}
+})

--- a/src/components/OrderHistory/OrderHistory.container.js
+++ b/src/components/OrderHistory/OrderHistory.container.js
@@ -1,9 +1,11 @@
 import { connect } from 'react-redux'
+import { getMarketPair } from '../../redux/selectors/meta'
 import { getOrderHistory } from '../../redux/selectors/ws'
 import OrderHistory from './OrderHistory'
 
 const mapStateToProps = (state) => ({
   orders: getOrderHistory(state),
+  getMarketPair: getMarketPair(state),
 })
 
 export default connect(mapStateToProps)(OrderHistory)

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 
 import _isEmpty from 'lodash/isEmpty'
@@ -8,14 +8,15 @@ import {
 import { useTranslation } from 'react-i18next'
 import Panel from '../../ui/Panel'
 import useSize from '../../hooks/useSize'
-import { ROW_MAPPING } from './OrderHistory.colunms'
+import { getRowMapping } from './OrderHistory.colunms'
 import './style.css'
 
 const OrderHistory = ({
-  onRemove, dark, orders,
+  onRemove, dark, orders, getMarketPair,
 }) => {
   const [ref, { width }] = useSize()
   const { t } = useTranslation()
+  const columns = useMemo(() => getRowMapping(getMarketPair), [getMarketPair])
 
   return (
     <Panel
@@ -30,7 +31,7 @@ const OrderHistory = ({
         ) : (
           <UfxOrderHistory
             orders={orders}
-            rowMapping={ROW_MAPPING}
+            rowMapping={columns}
             isMobileLayout={width < 700}
           />
         )}
@@ -43,6 +44,7 @@ OrderHistory.propTypes = {
   orders: PropTypes.arrayOf(PropTypes.object),
   dark: PropTypes.bool,
   onRemove: PropTypes.func,
+  getMarketPair: PropTypes.func.isRequired,
 }
 
 OrderHistory.defaultProps = {

--- a/src/components/PositionsTable/PositionsTable.columns.js
+++ b/src/components/PositionsTable/PositionsTable.columns.js
@@ -9,12 +9,12 @@ const STYLES = {
   rightAlign: { justifyContent: 'flex-end' },
 }
 
-export default ({ authToken, closePosition, t }) => [{
+export default (authToken, closePosition, t, getMarketPair) => [{
   label: t('table.pair'),
   dataKey: 'symbol',
   width: 145,
   flexGrow: 1.5,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.uiID),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(getMarketPair(rowData.symbol)),
 }, {
   label: t('table.amount'),
   dataKey: 'amount',

--- a/src/components/PositionsTable/PositionsTable.container.js
+++ b/src/components/PositionsTable/PositionsTable.container.js
@@ -3,6 +3,7 @@ import { prepareAmount } from 'bfx-api-node-util'
 import Debug from 'debug'
 
 import { getAuthToken, getAllPositions, getFilteredPositions } from '../../redux/selectors/ws'
+import { getMarketPair } from '../../redux/selectors/meta'
 import orders from '../../orders'
 import WSActions from '../../redux/actions/ws'
 import PositionsTable from './PositionsTable'
@@ -13,6 +14,7 @@ const mapStateToProps = (state, { activeFilter } = {}) => ({
   authToken: getAuthToken(state),
   filteredPositions: getFilteredPositions(state)(activeFilter),
   positions: getAllPositions(state),
+  getMarketPair: getMarketPair(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/PositionsTable/PositionsTable.js
+++ b/src/components/PositionsTable/PositionsTable.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { VirtualTable } from '@ufx-ui/core'
 import _isEmpty from 'lodash/isEmpty'
@@ -6,15 +6,20 @@ import { useTranslation } from 'react-i18next'
 import PositionsTableColumns from './PositionsTable.columns'
 
 const PositionsTable = (props) => {
-  const { t } = useTranslation()
   const {
     closePosition,
     authToken,
     filteredPositions,
     positions,
     renderedInTradingState,
+    getMarketPair,
   } = props
 
+  const { t } = useTranslation()
+  const columns = useMemo(
+    () => PositionsTableColumns(authToken, closePosition, t, getMarketPair),
+    [authToken, closePosition, getMarketPair, t],
+  )
   const data = renderedInTradingState ? filteredPositions : positions
 
   if (_isEmpty(data)) {
@@ -24,7 +29,7 @@ const PositionsTable = (props) => {
   return (
     <VirtualTable
       data={data}
-      columns={PositionsTableColumns({ authToken, closePosition, t })}
+      columns={columns}
       defaultSortBy='id'
       defaultSortDirection='ASC'
     />
@@ -34,14 +39,15 @@ const PositionsTable = (props) => {
 PositionsTable.propTypes = {
   closePosition: PropTypes.func.isRequired,
   authToken: PropTypes.string.isRequired,
-  filteredPositions: PropTypes.arrayOf(PropTypes.object),
-  positions: PropTypes.arrayOf(PropTypes.object),
+  filteredPositions: PropTypes.objectOf(PropTypes.object),
+  positions: PropTypes.objectOf(PropTypes.object),
   renderedInTradingState: PropTypes.bool,
+  getMarketPair: PropTypes.func.isRequired,
 }
 
 PositionsTable.defaultProps = {
-  filteredPositions: [],
-  positions: [],
+  filteredPositions: {},
+  positions: {},
   renderedInTradingState: false,
 }
 

--- a/src/redux/adapters/ws.js
+++ b/src/redux/adapters/ws.js
@@ -31,12 +31,16 @@ const notificationAdapter = (data = []) => {
       mts: data[0],
       type: data[1],
       status: _toUpper(data[4].level),
+      level: _toUpper(data[4].level),
       text: data[4].message,
+      message: data[4].message,
     }
   }
   const notification = new Notification(data).toJS()
   notification.cid = data.cid || data.uid
   notification.i18n = data.i18n || null
+  notification.level = data.status
+  notification.message = data.text
 
   return notification
 }

--- a/src/redux/middleware/ui/index.js
+++ b/src/redux/middleware/ui/index.js
@@ -1,4 +1,6 @@
 import { v4 } from 'uuid'
+import { i18n } from '@ufx-ui/core'
+
 import UIActions from '../../actions/ui'
 import UITypes from '../../constants/ui'
 
@@ -11,9 +13,8 @@ export default () => {
         store.dispatch(UIActions.recvNotification({
           mts: Date.now(),
           status: 'success',
-          text: 'Successfully saved layout',
+          text: i18n.t('notifications.layoutSaved'),
           cid: v4(),
-          i18n: { key: 'notifications.layoutSaved' },
         }))
         next(action)
         break

--- a/src/redux/middleware/ws/on_message.js
+++ b/src/redux/middleware/ws/on_message.js
@@ -3,6 +3,7 @@ import _isObject from 'lodash/isObject'
 import _isNumber from 'lodash/isNumber'
 import Debug from 'debug'
 import { v4 } from 'uuid'
+import { i18n as i18nLib } from '@ufx-ui/core'
 
 import UIActions from '../../actions/ui'
 import WSActions from '../../actions/ws'
@@ -135,27 +136,21 @@ export default (alias, store) => (e = {}) => {
 
       case 'error': {
         const [, message, i18n] = payload
-        if (i18n) {
-          i18n.key = `notifications.${i18n.key}`
-        }
+
         store.dispatch(WSActions.recvNotification({
           status: 'error',
-          text: message,
+          text: i18n ? i18nLib.t(`notifications.${i18n.key}`) : message,
           mts: Date.now(),
           cid: v4(),
-          i18n,
         }))
         break
       }
 
       case 'notify': {
         const [, status, message, i18n] = payload
-        if (i18n) {
-          i18n.key = `notifications.${i18n.key}`
-        }
         const notificationObject = {
           status,
-          text: message,
+          text: i18n ? i18nLib.t(`notifications.${i18n.key}`) : message,
           mts: Date.now(),
           cid: v4(),
           i18n,

--- a/src/redux/reducers/ws/algo_orders.js
+++ b/src/redux/reducers/ws/algo_orders.js
@@ -1,9 +1,10 @@
-import _filter from 'lodash/filter'
+import _omit from 'lodash/omit'
+import _forEach from 'lodash/forEach'
 
 import types from '../../constants/ws'
 
 const getInitialState = () => {
-  return []
+  return {}
 }
 
 export default (state = getInitialState(), action = {}) => {
@@ -12,23 +13,27 @@ export default (state = getInitialState(), action = {}) => {
   switch (type) {
     case types.DATA_ALGO_ORDERS: {
       const { aos } = payload
-      return aos
+      const transformed = {}
+      _forEach(aos, ao => {
+        transformed[ao?.gid] = ao
+      })
+
+      return transformed
     }
 
     case types.DATA_ALGO_ORDER: {
       const { ao } = payload
-      const filtered = _filter(state, ({ gid }) => gid !== ao.gid)
 
-      return [
-        ...filtered,
-        ao,
-      ]
+      return {
+        ...state,
+        [ao?.gid]: ao,
+      }
     }
 
     case types.DATA_ALGO_ORDER_STOPPED: {
       const { gid } = payload
 
-      return _filter(state, ao => ao.gid !== gid)
+      return _omit(state, gid)
     }
 
     case types.CLEAR_ALGO_ORDERS:

--- a/src/redux/reducers/ws/orders.js
+++ b/src/redux/reducers/ws/orders.js
@@ -1,11 +1,11 @@
-import _map from 'lodash/map'
-import _filter from 'lodash/filter'
+import _omit from 'lodash/omit'
+import _forEach from 'lodash/forEach'
 
 import types from '../../constants/ws'
 import { orderAdapter } from '../../adapters/ws'
 
 const getInitialState = () => {
-  return []
+  return {}
 }
 
 export default (state = getInitialState(), action = {}) => {
@@ -14,26 +14,30 @@ export default (state = getInitialState(), action = {}) => {
   switch (type) {
     case types.DATA_ORDERS: {
       const { orders = [] } = payload
+      const transformed = {}
+      _forEach(orders, order => {
+        const adapted = orderAdapter(order)
+        transformed[adapted?.id] = adapted
+      })
 
-      return _map(orders, orderAdapter)
+      return transformed
     }
 
     case types.DATA_ORDER: {
       const { order = [] } = payload
       const adapted = orderAdapter(order)
-      const filtered = _filter(state, ({ id, gid }) => id !== adapted.id || gid !== adapted.gid)
 
-      return [
-        ...filtered,
-        adapted,
-      ]
+      return {
+        ...state,
+        [adapted?.id]: adapted,
+      }
     }
 
     case types.DATA_ORDER_CLOSE: {
       const { order = [] } = payload
-      const o = orderAdapter(order)
+      const adapted = orderAdapter(order)
 
-      return _filter(state, or => o.id !== or.id)
+      return _omit(state, adapted?.id)
     }
 
     case types.DEAUTH: {

--- a/src/redux/reducers/ws/strategies.js
+++ b/src/redux/reducers/ws/strategies.js
@@ -1,4 +1,5 @@
 import _keyBy from 'lodash/keyBy'
+import _omit from 'lodash/omit'
 import t from '../../constants/ws'
 
 const getInitialState = () => {
@@ -13,19 +14,18 @@ export default function (state = getInitialState(), action = {}) {
       const { strategy } = payload
       return {
         ...state,
-        [strategy.id]: strategy,
+        [strategy?.id]: strategy,
       }
     }
     case t.DATA_REMOVE_STRATEGY: {
       const { id } = payload
-      const strategies = { ...state }
-      delete strategies[id]
-      return strategies
+
+      return _omit(state, id)
     }
 
     case t.DATA_STRATEGIES: {
       const { strategies } = payload
-      return _keyBy(strategies, s => s.id)
+      return _keyBy(strategies, s => s?.id)
     }
 
     case t.DEAUTH: {

--- a/src/redux/sagas/ws/on_connected.js
+++ b/src/redux/sagas/ws/on_connected.js
@@ -1,5 +1,7 @@
 import { put } from 'redux-saga/effects'
 import { v4 } from 'uuid'
+import { i18n } from '@ufx-ui/core'
+
 import A from '../../actions/ws'
 import { getAuthToken } from '../../../util/token_store'
 import WSTypes from '../../constants/ws'
@@ -17,9 +19,8 @@ export default function* ({ payload }) {
   yield put(A.recvNotification({
     mts: Date.now(),
     status: 'success',
-    text: 'Successfully connected to websocket server',
+    text: i18n.t('notifications.wsConnected'),
     cid: v4(),
-    i18n: { key: 'notifications.wsConnected' },
   }))
 
   if (!isElectronApp && payload.alias === WSTypes.ALIAS_API_SERVER) {

--- a/src/redux/sagas/ws/on_disconnected.js
+++ b/src/redux/sagas/ws/on_disconnected.js
@@ -1,13 +1,13 @@
 import { put } from 'redux-saga/effects'
 import { v4 } from 'uuid'
+import { i18n } from '@ufx-ui/core'
 import WSActions from '../../actions/ws'
 
 export default function* () {
   yield put(WSActions.recvNotification({
     mts: Date.now(),
     status: 'error',
-    text: 'Disconnected from websocket server',
+    text: i18n.t('notifications.wsDisconnected'),
     cid: v4(),
-    i18n: { key: 'notifications.wsDisconnected' },
   }))
 }

--- a/src/redux/selectors/meta/get_markets.js
+++ b/src/redux/selectors/meta/get_markets.js
@@ -1,8 +1,28 @@
 import _get from 'lodash/get'
+import { createSelector } from 'reselect'
+import memoizeOne from 'memoize-one'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
+import { getPairFromMarket } from '../../../util/market'
+
 import { REDUCER_PATHS } from '../../config'
+
+const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.META
 
 const EMPTY_OBJ = {}
 
-export default (state) => _get(state, `${path}.markets`, EMPTY_OBJ)
+const getMarkets = (state) => _get(state, `${path}.markets`, EMPTY_OBJ)
+
+export const getMarketPair = createSelector(
+  [
+    getMarkets,
+    getCurrencySymbolMemo,
+  ],
+  (markets, getCurrencySymbol) => memoizeOne((symbol) => {
+    const currentMarket = markets?.[symbol]
+    return getPairFromMarket(currentMarket, getCurrencySymbol)
+  }),
+)
+
+export default getMarkets

--- a/src/redux/selectors/meta/index.js
+++ b/src/redux/selectors/meta/index.js
@@ -1,4 +1,4 @@
-import getMarkets from './get_markets'
+import getMarkets, { getMarketPair } from './get_markets'
 import getMarketBySymbol from './get_market_by_symbol'
 import getTicker from './get_ticker'
 import getTickersKeys from './get_tickers_keys'
@@ -6,6 +6,7 @@ import getTickersArray from './get_tickers_array'
 
 export {
   getMarkets,
+  getMarketPair,
   getMarketBySymbol,
   getTicker,
   getTickersArray,

--- a/src/redux/selectors/ws/get_algo_orders.js
+++ b/src/redux/selectors/ws/get_algo_orders.js
@@ -1,40 +1,13 @@
 import _get from 'lodash/get'
-import _map from 'lodash/map'
-import { createSelector } from 'reselect'
-import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
-import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
-import { getMarkets } from '../meta'
-
-const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
-const EMPTY_ARR = []
+const EMPTY_OBJ = {}
 
-const algoOrders = (state) => {
-  return _get(state, `${path}.algoOrders`, EMPTY_ARR)
+const getAlgoOrders = (state) => {
+  return _get(state, `${path}.algoOrders`, EMPTY_OBJ)
 }
 
-const algoOrdersWithReplacedPairs = createSelector(
-  [
-    getMarkets,
-    algoOrders,
-    getCurrencySymbolMemo,
-  ], (markets, orders, getCurrencySymbol) => {
-    return _map(orders, (order) => {
-      const currentMarket = markets[order?.args?.symbol]
-
-      return {
-        ...order,
-        args: {
-          ...order?.args,
-          uiID: getPairFromMarket(currentMarket, getCurrencySymbol),
-        },
-      }
-    })
-  },
-)
-
-export default algoOrdersWithReplacedPairs
+export default getAlgoOrders

--- a/src/redux/selectors/ws/get_all_balances.js
+++ b/src/redux/selectors/ws/get_all_balances.js
@@ -3,6 +3,6 @@ import { REDUCER_PATHS } from '../../config'
 
 const path = REDUCER_PATHS.WS
 
-const EMPTY_ARR = []
+const EMPTY_OBJ = {}
 
-export default (state) => _get(state, `${path}.balances`, EMPTY_ARR)
+export default (state) => _get(state, `${path}.balances`, EMPTY_OBJ)

--- a/src/redux/selectors/ws/get_all_positions.js
+++ b/src/redux/selectors/ws/get_all_positions.js
@@ -1,37 +1,13 @@
 import _get from 'lodash/get'
-import _map from 'lodash/map'
-import { createSelector } from 'reselect'
-import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
-import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
-import { getMarkets } from '../meta'
-
-const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
-const EMPTY_ARR = []
+const EMPTY_OBJ = {}
 
-const allPositions = (state) => {
-  return _get(state, `${path}.positions`, EMPTY_ARR)
+const getAllPositions = (state) => {
+  return _get(state, `${path}.positions`, EMPTY_OBJ)
 }
 
-const positionWithReplacedPairs = createSelector(
-  [
-    getMarkets,
-    allPositions,
-    getCurrencySymbolMemo,
-  ], (markets, positions, getCurrencySymbol) => {
-    return _map(positions, (position) => {
-      const currentMarket = markets?.[position?.symbol]
-
-      return {
-        ...position,
-        uiID: getPairFromMarket(currentMarket, getCurrencySymbol),
-      }
-    })
-  },
-)
-
-export default positionWithReplacedPairs
+export default getAllPositions

--- a/src/redux/selectors/ws/get_atomic_orders.js
+++ b/src/redux/selectors/ws/get_atomic_orders.js
@@ -3,10 +3,10 @@ import { REDUCER_PATHS } from '../../config'
 
 const path = REDUCER_PATHS.WS
 
-const EMPTY_ARR = []
+const EMPTY_OBJ = {}
 
 const getAtomicOrders = (state) => {
-  return _get(state, `${path}.orders`, EMPTY_ARR)
+  return _get(state, `${path}.orders`, EMPTY_OBJ)
 }
 
 export default getAtomicOrders

--- a/src/redux/selectors/ws/get_atomic_orders.js
+++ b/src/redux/selectors/ws/get_atomic_orders.js
@@ -1,37 +1,12 @@
 import _get from 'lodash/get'
-import _map from 'lodash/map'
-import { createSelector } from 'reselect'
-import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import { REDUCER_PATHS } from '../../config'
-import { getMarkets } from '../meta'
-import { getPairFromMarket } from '../../../util/market'
-
-const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
 
 const EMPTY_ARR = []
 
-const atomicOrders = (state) => {
+const getAtomicOrders = (state) => {
   return _get(state, `${path}.orders`, EMPTY_ARR)
 }
 
-const atomicOrdersWithReplacedPairs = createSelector(
-  [
-    getMarkets,
-    atomicOrders,
-    getCurrencySymbolMemo,
-  ],
-  (markets, orders, getCurrencySymbol) => {
-    return _map(orders, (order) => {
-      const currentMarket = markets?.[order?.symbol]
-
-      return {
-        ...order,
-        uiID: getPairFromMarket(currentMarket, getCurrencySymbol),
-      }
-    })
-  },
-)
-
-export default atomicOrdersWithReplacedPairs
+export default getAtomicOrders

--- a/src/redux/selectors/ws/get_filtered_algo_orders.js
+++ b/src/redux/selectors/ws/get_filtered_algo_orders.js
@@ -1,5 +1,5 @@
 import _isEmpty from 'lodash/isEmpty'
-import _filter from 'lodash/filter'
+import _reduce from 'lodash/reduce'
 import { createSelector } from 'reselect'
 import memoizeOne from 'memoize-one'
 
@@ -12,7 +12,12 @@ const getFilteredAlgoOrders = createSelector(
       return orders
     }
 
-    return _filter(orders, o => o?.args?.symbol === activeFilter?.wsID)
+    return _reduce(orders, (acc, o) => {
+      if (o?.args?.symbol === activeFilter?.wsID) {
+        acc[o?.gid] = o
+      }
+      return acc
+    }, {})
   }),
 )
 

--- a/src/redux/selectors/ws/get_filtered_algo_orders_count.js
+++ b/src/redux/selectors/ws/get_filtered_algo_orders_count.js
@@ -1,10 +1,11 @@
 import { createSelector } from 'reselect'
+import _size from 'lodash/size'
 
 import getFilteredAlgoOrders from './get_filtered_algo_orders'
 
 const getFilteredAlgoOrdersCount = createSelector(
   getFilteredAlgoOrders,
-  (getOrders) => (activeFilter) => getOrders(activeFilter)?.length,
+  (getOrders) => (activeFilter) => _size(getOrders(activeFilter)),
 )
 
 export default getFilteredAlgoOrdersCount

--- a/src/redux/selectors/ws/get_filtered_atomic_orders.js
+++ b/src/redux/selectors/ws/get_filtered_atomic_orders.js
@@ -1,5 +1,5 @@
 import _isEmpty from 'lodash/isEmpty'
-import _filter from 'lodash/filter'
+import _reduce from 'lodash/reduce'
 import { createSelector } from 'reselect'
 import memoizeOne from 'memoize-one'
 
@@ -12,7 +12,12 @@ const getFilteredAtomicOrders = createSelector(
       return orders
     }
 
-    return _filter(orders, o => o?.symbol === activeFilter?.wsID)
+    return _reduce(orders, (acc, o) => {
+      if (o?.symbol === activeFilter?.wsID) {
+        acc[o?.id] = o
+      }
+      return acc
+    }, {})
   }),
 )
 

--- a/src/redux/selectors/ws/get_filtered_atomic_orders_count.js
+++ b/src/redux/selectors/ws/get_filtered_atomic_orders_count.js
@@ -1,10 +1,11 @@
 import { createSelector } from 'reselect'
+import _size from 'lodash/size'
 
 import getFilteredAtomicOrders from './get_filtered_atomic_orders'
 
 const getFilteredAtomicOrdersCount = createSelector(
   getFilteredAtomicOrders,
-  (getOrders) => (activeFilter) => getOrders(activeFilter)?.length,
+  (getOrders) => (activeFilter) => _size(getOrders(activeFilter)),
 )
 
 export default getFilteredAtomicOrdersCount

--- a/src/redux/selectors/ws/get_filtered_balances.js
+++ b/src/redux/selectors/ws/get_filtered_balances.js
@@ -1,8 +1,9 @@
 import _isEmpty from 'lodash/isEmpty'
-import _filter from 'lodash/filter'
+import _reduce from 'lodash/reduce'
 import { createSelector } from 'reselect'
 
 import getAllBalances from './get_all_balances'
+import { getKey } from '../../reducers/ws/balances'
 
 const getFilteredBalances = createSelector(
   getAllBalances,
@@ -13,9 +14,14 @@ const getFilteredBalances = createSelector(
     }
 
     const { base, quote } = activeFilter
-    const filteredBalances = _filter(balances, ({ currency }) => currency === base || currency === quote)
 
-    return filteredBalances
+    return _reduce(balances, (acc, b) => {
+      const { currency } = b || {}
+      if (currency === base || currency === quote) {
+        acc[getKey(b)] = b
+      }
+      return acc
+    }, {})
   },
 )
 

--- a/src/redux/selectors/ws/get_filtered_positions.js
+++ b/src/redux/selectors/ws/get_filtered_positions.js
@@ -1,5 +1,5 @@
 import _isEmpty from 'lodash/isEmpty'
-import _filter from 'lodash/filter'
+import _reduce from 'lodash/reduce'
 import { createSelector } from 'reselect'
 import memoizeOne from 'memoize-one'
 
@@ -12,7 +12,12 @@ const getFilteredPositions = createSelector(
       return positions
     }
 
-    return _filter(positions, p => p?.symbol === activeFilter?.wsID)
+    return _reduce(positions, (acc, p) => {
+      if (p?.symbol === activeFilter?.wsID) {
+        acc[p?.id] = p
+      }
+      return acc
+    }, {})
   }),
 )
 

--- a/src/redux/selectors/ws/get_filtered_positions_count.js
+++ b/src/redux/selectors/ws/get_filtered_positions_count.js
@@ -1,10 +1,11 @@
 import { createSelector } from 'reselect'
+import _size from 'lodash/size'
 
 import getFilteredPositions from './get_filtered_positions'
 
 const getFilteredPositionsCount = createSelector(
   getFilteredPositions,
-  (getPositions) => (activeFilter) => getPositions(activeFilter)?.length,
+  (getPositions) => (activeFilter) => _size(getPositions(activeFilter)),
 )
 
 export default getFilteredPositionsCount

--- a/src/redux/selectors/ws/get_order_history.js
+++ b/src/redux/selectors/ws/get_order_history.js
@@ -1,29 +1,11 @@
 import _get from 'lodash/get'
-import _map from 'lodash/map'
-import { createSelector } from 'reselect'
-import { reduxSelectors } from '@ufx-ui/bfx-containers'
-import { getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
-import { getMarkets } from '../meta'
-
-const { getCurrencySymbolMemo } = reduxSelectors
 
 const path = REDUCER_PATHS.WS
-const EMPTY_ARR = []
+const EMPTY_OBJ = {}
 
-const orderHistory = (state) => {
-  return _get(state, `${path}.orderHistory`, EMPTY_ARR)
+const getOrderHistory = (state) => {
+  return _get(state, `${path}.orderHistory`, EMPTY_OBJ)
 }
 
-const orderHistoryWithReplacedPairs = createSelector([getMarkets, orderHistory, getCurrencySymbolMemo], (markets, orders, getCurrencySymbol) => {
-  return _map(orders, (order) => {
-    const currentMarket = markets?.[order?.symbol]
-
-    return {
-      ...order,
-      symbol: getPairFromMarket(currentMarket, getCurrencySymbol),
-    }
-  })
-})
-
-export default orderHistoryWithReplacedPairs
+export default getOrderHistory


### PR DESCRIPTION
Notifications
- simplify notifications retrieval logic
- use fn comp
- avoid rendering of all old notifications nodes when new notification is received

Orders/AlgoOrders/Positions/OrderHistory/Balances
- avoid wasted renders
- use state in object from except for OrderHistory

Update to ufx -> 0.10.11 to get perf improvement changes for Notifications/VirtuableTable