### PR TITLE
(fix) Ping/Pong additional fields are not displayed when using saved algo settings

### DIFF
--- a/src/components/OrderForm/OrderForm.helpers.js
+++ b/src/components/OrderForm/OrderForm.helpers.js
@@ -46,7 +46,7 @@ const marketToQuoteBase = (market) => ({
 
 const verifyCondition = (condition = {}, value) => {
   if (typeof condition.eq !== 'undefined') {
-    return condition.eq === value
+    return condition.eq == value // eslint-disable-line
   }
   if (typeof condition.neq !== 'undefined') {
     return condition.neq !== value

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -429,12 +429,14 @@ class OrderForm extends React.Component {
           extraIcons={[
             !helpOpen && currentLayout && currentLayout.customHelp && (
               <Icon
+                key='question'
                 name='question'
                 onClick={this.onToggleHelp}
               />
             ),
             !helpOpen && currentLayout && currentLayout.id && (
               <AOParamSettings
+                key='ao-settings'
                 algoID={currentLayout.id}
                 symbol={activeMarket.wsID}
                 processAOData={this.processAOData}


### PR DESCRIPTION
ASANA Ticket: [BUG: saved ping pong order count 1 will not display](https://app.asana.com/0/1125859137800433/1201202846214678/f)

UI Demonstration:

https://user-images.githubusercontent.com/35810911/137522499-78690e88-778f-4a69-80d9-f198cb9d94ce.mp4
