### PR TITLE
(fix) show 'bad-connection-modal' always on top of other modals

### DIFF
--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -104,9 +104,9 @@ const HFUI = ({
           {isElectronApp ? (
             <>
               <TradingModeModal />
-              <BadConnectionModal />
               <OldFormatModal />
               <AOPauseModal />
+              <BadConnectionModal />
             </>
           ) : (
             <BestExperienceMessageModal />

--- a/src/components/StatusBar/StatusBar.container.js
+++ b/src/components/StatusBar/StatusBar.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 
 import StatusBar from './StatusBar'
-import { getRemoteVersion, getIsInternetConnection } from '../../redux/selectors/ui'
+import { getRemoteVersion, getIsBadInternetConnection } from '../../redux/selectors/ui'
 import {
   apiClientConnected, apiClientConnecting, apiClientDisconnected, getCurrentModeAPIKeyState, isSocketConnected,
 } from '../../redux/selectors/ws'
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => ({
   apiClientDisconnected: apiClientDisconnected(state),
   apiClientConnecting: apiClientConnecting(state),
   apiClientConnected: apiClientConnected(state),
-  wsInterrupted: getIsInternetConnection(state),
+  wsInterrupted: getIsBadInternetConnection(state),
   currentModeApiKeyState: getCurrentModeAPIKeyState(state),
 })
 

--- a/src/modals/BadConnectionModal/BadConnectionModal.container.js
+++ b/src/modals/BadConnectionModal/BadConnectionModal.container.js
@@ -5,13 +5,13 @@ import WSActions from '../../redux/actions/ws'
 import GAActions from '../../redux/actions/google_analytics'
 import UIActions from '../../redux/actions/ui'
 import {
-  getIsInternetConnection, SETTINGS, getRebootSetting,
+  getIsBadInternetConnection, SETTINGS, getRebootSetting,
 } from '../../redux/selectors/ui'
 
 import BadConnectionModal from './BadConnectionModal'
 
 const mapStateToProps = (state = {}) => ({
-  visible: getIsInternetConnection(state),
+  visible: getIsBadInternetConnection(state),
   rebootAutomatically: getRebootSetting(state),
 })
 

--- a/src/pages/Trading/Trading.container.js
+++ b/src/pages/Trading/Trading.container.js
@@ -7,6 +7,7 @@ import { getHasActiveAlgoOrders, getShowActiveAlgoModal } from '../../redux/sele
 import {
   getFirstLogin,
   getGuideStatusForPage,
+  getIsBadInternetConnection,
 } from '../../redux/selectors/ui'
 
 import Trading from './Trading'
@@ -17,6 +18,7 @@ const mapStateToProps = (state = {}) => ({
   apiClientConnected: apiClientConnected(state),
   hasActiveAlgoOrders: getHasActiveAlgoOrders(state),
   isGuideActive: getGuideStatusForPage(state, TRADING_PAGE),
+  isBadConnection: getIsBadInternetConnection(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/pages/Trading/Trading.js
+++ b/src/pages/Trading/Trading.js
@@ -34,6 +34,7 @@ const Trading = ({
   apiClientConnected,
   hasActiveAlgoOrders,
   finishGuide,
+  isBadConnection,
 }) => {
   const { t } = useTranslation()
 
@@ -66,7 +67,7 @@ const Trading = ({
           />
         </div>
 
-        <ActiveAlgoOrdersModal isOpen={showAlgoModal && hasActiveAlgoOrders && apiClientConnected} />
+        <ActiveAlgoOrdersModal isOpen={showAlgoModal && hasActiveAlgoOrders && apiClientConnected && !isBadConnection} />
         {/* <RefillBalanceModal /> */}
       </Layout.Main>
       <Layout.Footer />
@@ -81,6 +82,7 @@ Trading.propTypes = {
   apiClientConnected: PropTypes.bool,
   hasActiveAlgoOrders: PropTypes.bool,
   finishGuide: PropTypes.func.isRequired,
+  isBadConnection: PropTypes.bool.isRequired,
 }
 
 Trading.defaultProps = {

--- a/src/redux/selectors/ui/index.js
+++ b/src/redux/selectors/ui/index.js
@@ -4,7 +4,7 @@ import getLayouts from './get_layouts'
 import getLayoutID from './get_layout_id'
 import getRemoteVersion from './get_remote_version'
 import getIsTradingModeModalVisible from './get_is_trading_mode_modal_visible'
-import getIsInternetConnection from './get_is_bad_internet_connection'
+import getIsBadInternetConnection from './get_is_bad_internet_connection'
 import getIsAOPausedModalVisible from './get_is_ao_paused'
 import getOldFormatModalState from './get_old_modal_format_state'
 import getIsRefillBalanceModalVisible from './get_is_refill_balance_modal_visible'
@@ -29,7 +29,7 @@ export {
   getLayouts,
   getLayoutID,
   getIsTradingModeModalVisible,
-  getIsInternetConnection,
+  getIsBadInternetConnection,
   getIsRefillBalanceModalVisible,
   getIsPaperTrading,
   getFirstLogin,


### PR DESCRIPTION
Fixes: https://github.com/bitfinexcom/bfx-hf-ui/issues/607