### PR TITLE
(fix) AO Table Invalid Date issue

### DIFF
--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
@@ -19,7 +19,7 @@ export default (authToken, cancelOrder, gaCancelOrder, t, getMarketPair) => [{
   dataKey: 'createdAt',
   width: 155,
   flexGrow: 1.55,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(new Date(rowData.createdAt).toLocaleString()),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(new Date(rowData.createdAt || +rowData.gid).toLocaleString()),
 }, {
   label: t('table.symbol'),
   dataKey: 'args.symbol',

--- a/src/modals/ActiveAlgoOrdersModal/ActiveAlgoOrdersModal.columns.js
+++ b/src/modals/ActiveAlgoOrdersModal/ActiveAlgoOrdersModal.columns.js
@@ -30,7 +30,7 @@ export default (onOrderSelect, isOrderSelected, t) => [{
   dataKey: 'createdAt',
   width: 125,
   flexGrow: 1.25,
-  cellRenderer: ({ rowData = {} }) => new Date(rowData.createdAt).toLocaleString(),
+  cellRenderer: ({ rowData = {} }) => new Date(rowData.createdAt || +rowData.gid).toLocaleString(),
 }, {
   label: t('table.symbol'),
   dataKey: 'args.symbol',


### PR DESCRIPTION
ASANA Ticket: [The Recover AO modal displays "invalid date"](https://app.asana.com/0/1125859137800433/1201215061747159/f)
https://github.com/bitfinexcom/bfx-hf-ui/issues/610

Using a `gid` property as a fallback if the `createdAt` value is `undefined` for some old AOs.