### PR TITLE
(feature) MACD Cross strategy

### DIFF
--- a/src/components/StrategyEditor/templates/index.js
+++ b/src/components/StrategyEditor/templates/index.js
@@ -1,9 +1,11 @@
 import VWAPExampleETHUSD from './vwap_example_eth_usd'
 import EMACross from './ema_cross'
+import MACDCross from './macd_cross'
 import Blank from './blank'
 
 export default [
   VWAPExampleETHUSD,
   EMACross,
+  MACDCross,
   Blank,
 ]

--- a/src/components/StrategyEditor/templates/macd_cross/defineIndicators.js
+++ b/src/components/StrategyEditor/templates/macd_cross/defineIndicators.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export default `(I) => {
   const indicators = {
     macd: new I.MACD([10, 26, 9])

--- a/src/components/StrategyEditor/templates/macd_cross/defineIndicators.js
+++ b/src/components/StrategyEditor/templates/macd_cross/defineIndicators.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+
+export default `(I) => {
+  const indicators = {
+    macd: new I.MACD([10, 26, 9])
+  }
+
+  indicators.macd.color = '#00ff00'
+
+  return indicators
+}`

--- a/src/components/StrategyEditor/templates/macd_cross/defineMeta.js
+++ b/src/components/StrategyEditor/templates/macd_cross/defineMeta.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export default `() => ({
   id: 'macd_cross',
   name: 'Simple MACD Cross Strategy',

--- a/src/components/StrategyEditor/templates/macd_cross/defineMeta.js
+++ b/src/components/StrategyEditor/templates/macd_cross/defineMeta.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+
+export default `() => ({
+  id: 'macd_cross',
+  name: 'Simple MACD Cross Strategy',
+  tf: '1h',
+})`

--- a/src/components/StrategyEditor/templates/macd_cross/index.js
+++ b/src/components/StrategyEditor/templates/macd_cross/index.js
@@ -1,0 +1,11 @@
+import defineIndicators from './defineIndicators'
+import defineMeta from './defineMeta'
+
+import onPriceUpdate from './onPriceUpdate'
+
+export default {
+  label: 'Basic MACD Cross',
+  defineIndicators,
+  defineMeta,
+  onPriceUpdate,
+}

--- a/src/components/StrategyEditor/templates/macd_cross/onPriceUpdate.js
+++ b/src/components/StrategyEditor/templates/macd_cross/onPriceUpdate.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export default `const whenShort = async (state = {}, update = {}) => {
   const { price, mts } = update
   const { macd } = HFS.indicatorValues(state)

--- a/src/components/StrategyEditor/templates/macd_cross/onPriceUpdate.js
+++ b/src/components/StrategyEditor/templates/macd_cross/onPriceUpdate.js
@@ -1,0 +1,80 @@
+/* eslint-disable */
+
+export default `const whenShort = async (state = {}, update = {}) => {
+  const { price, mts } = update
+  const { macd } = HFS.indicatorValues(state)
+
+  if (macd.macd > macd.signal) {
+    return HFS.closePositionMarket(state, { price, mtsCreate: mts })
+  }
+
+  return state
+}
+
+const whenLong = async (state = {}, update = {}) => {
+  const { price, mts } = update
+  const { macd } = HFS.indicatorValues(state)
+
+  if (macd.macd < macd.signal) {
+    return HFS.closePositionMarket(state, { price, mtsCreate: mts })
+  }
+
+  return state
+}
+
+const lookForTrade = async (state = {}, update = {}) => {
+  const { price, mts } = update
+  const { macd } = HFS.indicators(state)
+  const current = macd.v()
+  const previous = macd.prev()
+
+  if (macd.l() < 2) {
+    return state // await sufficient data
+  }
+
+  const crossedOver = (
+    (current.macd >= current.signal) &&
+    (previous.macd <= previous.signal)
+  )
+
+  if (crossedOver) {
+    return HFS.openLongPositionMarket(state, {
+      mtsCreate: mts,
+      amount: 1,
+      price
+    })
+  }
+
+  const crossedUnder = (
+    (current.macd <= current.signal) &&
+    (previous.macd >= previous.signal)
+  )
+
+  if (crossedUnder) {
+    return HFS.openShortPositionMarket(state, {
+      mtsCreate: mts,
+      amount: 1,
+      price
+    })
+  }
+
+  return state
+}
+
+({ HFS, HFU }) => async (state = {}, update = {}) => {
+  const position = HFS.getPosition(state)
+
+  if (!position) {
+    return lookForTrade(state, update)
+  }
+
+  if (HFS.isLong(state)) {
+    return whenLong(state, update)
+  }
+
+  if (HFS.isShort(state)) {
+    return whenShort(state, update)
+  }
+
+  return state
+}`

--- a/src/modals/Strategy/CreateNewStrategyModal/CreateNewStrategyModal.js
+++ b/src/modals/Strategy/CreateNewStrategyModal/CreateNewStrategyModal.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 
 import Templates from '../../../components/StrategyEditor/templates'
-
+import MACD from '../../../components/StrategyEditor/templates/macd_cross'
 import Input from '../../../ui/Input'
 import Modal from '../../../ui/Modal'
 import Dropdown from '../../../ui/Dropdown'
@@ -20,7 +20,7 @@ const CreateNewStrategyModal = ({
 }) => {
   const [label, setLabel] = useState('')
   const [error, setError] = useState('')
-  const [template, setTemplate] = useState('Blank')
+  const [template, setTemplate] = useState(MACD.label)
 
   const { t } = useTranslation()
 


### PR DESCRIPTION
ASANA Ticket: [Strategy Editor: add Macd cross as default strategy](https://app.asana.com/0/1125859137800433/1201243237227206/f)

Description:
 - added MACD Cross strategy (https://github.com/bitfinexcom/bfx-hf-strategy/tree/master/examples/macd_cross)
 - made MACD the default strategy choice when on 'Create new strategy' modal

UI Demonstration:
![Screenshot from 2021-10-21 15-16-58](https://user-images.githubusercontent.com/35810911/138277476-3e30a68b-c835-4d47-aea7-da1b399f5702.png)
![Screenshot from 2021-10-21 15-17-14](https://user-images.githubusercontent.com/35810911/138277521-7982257b-449f-4151-a5d3-24aa5a3a2e00.png)
![Screenshot from 2021-10-21 15-29-14](https://user-images.githubusercontent.com/35810911/138277524-4f964b33-4324-4e4a-ab6c-923be13ed2ba.png)


