### PR TITLE
(fix) Deleting AO template on hosted gives an error

### DIFF
--- a/src/components/OrderForm/Orderform.AlgoParams.js
+++ b/src/components/OrderForm/Orderform.AlgoParams.js
@@ -118,9 +118,11 @@ const AlgoParams = ({
                       onClick={() => onSelect(params)}
                     >
                       {makeShorterLongName(params.name, MAX_NAME_LENGTH)}
-                      <div className='hfui-orderform__ao-settings__delete'>
-                        <i className='icon-clear' role='button' aria-label='Delete Algo parameters' tabIndex={0} onClick={() => onDelete(params.id)} />
-                      </div>
+                      {!_isEmpty(params?.id) && (
+                        <div className='hfui-orderform__ao-settings__delete'>
+                          <i className='icon-clear' role='button' aria-label='Delete Algo parameters' tabIndex={0} onClick={() => onDelete(params.id)} />
+                        </div>
+                      )}
                     </Item>
                   ))}
                 </>


### PR DESCRIPTION
ASANA Ticket: [Algo order template: delete template gives error](https://app.asana.com/0/0/1201269620748636/f)

Description: Do not show delete button if AO setting ID is undefined. Newly created AO templates with IDs are fetched from API automatically after `data.algo_order_params.saved` event.