### PR TITLE
(fix) execute strategy candle seed is sent as string, not as a number

### DIFF
--- a/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
+++ b/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
@@ -39,8 +39,10 @@ const LiveStrategyExecutor = ({
 
   const updateSeed = (v) => {
     const error = AmountInput.validateValue(v)
+    const processed = AmountInput.processValue(v)
+
     setSeedError(error)
-    setCandleSeed(v)
+    setCandleSeed(processed)
   }
 
   if (_isEmpty(strategyContent)) {


### PR DESCRIPTION
ASANA Ticket: [[bug] execute candle seed is sent as string, not as a number](https://app.asana.com/0/1125859137800433/1201360265703483/f)

UI Demonstration:
Before:
![Screenshot from 2021-11-11 12-24-44](https://user-images.githubusercontent.com/35810911/141311888-cc0b05f1-a746-44f5-8455-c94fd124d1fc.png)

After:
![Screenshot from 2021-11-11 16-01-48](https://user-images.githubusercontent.com/35810911/141311930-cb70c4fe-0a6b-4602-adfd-6769aa3adced.png)

