### PR TITLE
(fix) i18n: resolved issue with set ws connected notification before i18n init

### DIFF
--- a/src/redux/sagas/ws/on_connected.js
+++ b/src/redux/sagas/ws/on_connected.js
@@ -1,4 +1,4 @@
-import { put, delay } from 'redux-saga/effects'
+import { put } from 'redux-saga/effects'
 import { v4 } from 'uuid'
 import i18n from '../../../locales/i18n'
 
@@ -16,13 +16,10 @@ export default function* ({ payload }) {
     yield put(A.reconnected())
   }
 
-  // delay so i18n is initialised
-  yield delay(50)
-
   yield put(A.recvNotification({
     mts: Date.now(),
     status: 'success',
-    text: i18n.t('notifications.wsConnected'),
+    text: i18n.isInitialized ? i18n.t('notifications.wsConnected') : 'Successfully connected to websocket server',
     cid: v4(),
   }))
 


### PR DESCRIPTION
ticket - https://app.asana.com/0/1125859137800433/1201388399992390

If i18n is not initialized when notification 'WS connected' it use default English text.