### PR TITLE
(fix) Deleting AO Setting causes it to open afterwards

### DIFF
--- a/src/components/OrderForm/Orderform.AlgoParams.js
+++ b/src/components/OrderForm/Orderform.AlgoParams.js
@@ -68,7 +68,8 @@ const AlgoParams = ({
     }
   }
 
-  const onDelete = (id) => {
+  const onDelete = (e, id) => {
+    e.stopPropagation()
     dispatch(setActiveAOParamsID(null))
     dispatch(removeAlgoOrderParams(algoID, symbol, id))
   }
@@ -119,8 +120,8 @@ const AlgoParams = ({
                     >
                       {makeShorterLongName(params.name, MAX_NAME_LENGTH)}
                       {!_isEmpty(params?.id) && (
-                        <div className='hfui-orderform__ao-settings__delete'>
-                          <i className='icon-clear' role='button' aria-label='Delete Algo parameters' tabIndex={0} onClick={() => onDelete(params.id)} />
+                        <div className='hfui-orderform__ao-settings__delete' onClick={(e) => onDelete(e, params.id)}>
+                          <i className='icon-clear' role='button' aria-label='Delete Algo parameters' tabIndex={0} />
                         </div>
                       )}
                     </Item>

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -770,9 +770,11 @@
 .hfui-orderform__ao-settings__menu {
   transform: translateX(-65%);
 
-  .hfui-orderform__ao-settings__delete > i {
-    width: 24px;
-    height: 24px;
+  .hfui-orderform__ao-settings__delete {
+    > i {
+      width: 24px;
+      height: 24px;
+    }
   }
 
   .hfui-orderform__ao-settings__item {


### PR DESCRIPTION
ASANA Ticket: [[bug] Algo Params delete action opens the deleted entry](https://app.asana.com/0/1125859137800433/1201388049133532/f)
Original issue: (1) https://github.com/bitfinexcom/bfx-hf-ui/issues/619

UI Demonstration:

https://user-images.githubusercontent.com/35810911/142250602-0b5920e8-373c-4978-8831-3d9fd20720f0.mp4
