### PR TITLE
(improvement) Saving OrderForm context as a AO parameter

### DIFF
--- a/src/components/OrderForm/Modals/AddNewParam/AddNewParam.js
+++ b/src/components/OrderForm/Modals/AddNewParam/AddNewParam.js
@@ -11,7 +11,7 @@ import { saveAlgoOrderParams } from '../../../../redux/actions/ao'
 const MAX_LABEL_LENGTH = 30
 
 const AddNewParamModal = ({
-  onClose, isOpen, algoID, symbol, processAOData, validateAOData,
+  onClose, isOpen, algoID, symbol, processAOData, validateAOData, context,
 }) => {
   const dispatch = useDispatch()
   const [name, setName] = useState('')
@@ -35,12 +35,16 @@ const AddNewParamModal = ({
       return
     }
 
-    const params = processAOData()
+    let params = processAOData()
     const errors = validateAOData(params)
     if (!_isEmpty(errors)) {
       const { field, message } = errors
       setError(`AO Params Validation Error: ${field} - ${message}`)
       return
+    }
+    params = {
+      ...params,
+      context,
     }
 
     const payload = {
@@ -80,6 +84,7 @@ AddNewParamModal.propTypes = {
   symbol: PropTypes.string.isRequired,
   processAOData: PropTypes.func.isRequired,
   validateAOData: PropTypes.func.isRequired,
+  context: PropTypes.string.isRequired,
 }
 
 export default memo(AddNewParamModal)

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -461,9 +461,11 @@ class OrderForm extends React.Component {
               <AOParamSettings
                 key='ao-settings'
                 algoID={currentLayout.id}
+                context={context}
                 symbol={activeMarket.wsID}
                 processAOData={this.processAOData}
                 setFieldData={this.setFieldData}
+                setContext={this.onContextChange}
                 validateAOData={this.validateAOData}
                 updateValidationErrors={this.updateValidationErrors}
               />

--- a/src/components/OrderForm/Orderform.AlgoParams.js
+++ b/src/components/OrderForm/Orderform.AlgoParams.js
@@ -39,7 +39,7 @@ const Item = ({
 )
 
 const AlgoParams = ({
-  algoID, symbol, processAOData, setFieldData, validateAOData, updateValidationErrors,
+  algoID, symbol, processAOData, setFieldData, validateAOData, updateValidationErrors, context, setContext,
 }) => {
   const dispatch = useDispatch()
   const [isOpen, setIsOpen] = useState(false)
@@ -52,12 +52,16 @@ const AlgoParams = ({
   const onSave = () => {
     if (!_isNull(activeAOID)) {
       const { name, id } = _find(selectedAOParams, (p) => p?.id === activeAOID)
-      const params = processAOData()
+      let params = processAOData()
       const errors = validateAOData(params)
 
       if (!_isEmpty(errors)) {
         updateValidationErrors(errors)
         return
+      }
+      params = {
+        ...params,
+        context,
       }
 
       const payload = {
@@ -81,6 +85,10 @@ const AlgoParams = ({
       if (percentageParams[i] in updatedParams) {
         updatedParams[percentageParams[i]] *= 100
       }
+    }
+
+    if (updatedParams?.context) {
+      setContext(updatedParams.context)
     }
 
     dispatch(setActiveAOParamsID(id))
@@ -136,6 +144,7 @@ const AlgoParams = ({
         onClose={() => setIsAddNewParamModalOpen(false)}
         algoID={algoID}
         symbol={symbol}
+        context={context}
         processAOData={processAOData}
         validateAOData={validateAOData}
       />
@@ -150,6 +159,8 @@ AlgoParams.propTypes = {
   setFieldData: PropTypes.func.isRequired,
   validateAOData: PropTypes.func.isRequired,
   updateValidationErrors: PropTypes.func.isRequired,
+  context: PropTypes.string.isRequired,
+  setContext: PropTypes.func.isRequired,
 }
 
 export default memo(AlgoParams)


### PR DESCRIPTION
ASANA Ticket: [[improvement] Algo Params: store exchange/margin setting](https://app.asana.com/0/1125859137800433/1201388049133537/f)
Original issue: https://github.com/bitfinexcom/bfx-hf-ui/issues/619

For older AO params the context value is ignored, but can be saved by pressing 'Save' button.

UI Demonstration:

https://user-images.githubusercontent.com/35810911/142505549-16cc63f3-929f-424e-9f30-2be45c937fa5.mp4


