### PR TITLE
(fix) orderform: fix enter/escape issues

### DIFF
--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -32,6 +32,7 @@ import ConnectingModal from './Modals/ConnectingModal'
 import UnconfiguredModal from './Modals/UnconfiguredModal'
 import SubmitAPIKeysModal from './Modals/SubmitAPIKeysModal'
 import OrderFormMenu from './OrderFormMenu'
+import { getIsAnyModalOpen } from '../../util/document'
 import { getAOs, getAtomicOrders } from './OrderForm.orders.helpers'
 
 import './style.css'
@@ -123,6 +124,11 @@ class OrderForm extends React.Component {
   }
 
   handleKeydown(e) {
+    // handle keys only when no modal is open, and it is orderform-details view
+    if (getIsAnyModalOpen() || !this.getIsOrderFormInputsView()) {
+      return
+    }
+
     const { isAlgoOrder } = this.state
     const { key } = e
     if (key === 'Escape') {
@@ -310,6 +316,20 @@ class OrderForm extends React.Component {
         },
       }))
     }
+  }
+
+  getIsOrderFormInputsView() {
+    const { apiClientState, apiCredentials } = this.props
+    const { currentLayout, helpOpen } = this.state
+
+    const apiClientConnected = apiClientState === 2
+    const apiClientConfigured = apiCredentials?.configured && apiCredentials?.valid
+    const isConnectedWithValidAPI = apiClientConnected && apiClientConfigured
+    const showOrderform = isConnectedWithValidAPI || !isElectronApp
+
+    const isOrderFormInputsView = !helpOpen && currentLayout && showOrderform
+
+    return isOrderFormInputsView
   }
 
   setFieldData(data) {
@@ -528,7 +548,7 @@ class OrderForm extends React.Component {
               </div>
             )}
 
-            {!helpOpen && currentLayout && showOrderform && [
+            {this.getIsOrderFormInputsView() && [
               <div className='hfui-orderform__layout-label' key='layout-label'>
                 <i
                   className='icon-back-arrow'

--- a/src/util/document.js
+++ b/src/util/document.js
@@ -1,0 +1,1 @@
+export const getIsAnyModalOpen = () => !!document.querySelector('#dialog-container .ufx-dialog .background.entered')


### PR DESCRIPTION
- fix: in orderform, select limit order, click help will open help modal, press escape will switch to order-selection view,
  again select limit order, now it always shows help-modal and can't see limit order inputs view
- fix: orderform accepts escape/enter events when it is intended for any open modal. fixes: https://github.com/bitfinexcom/bfx-hf-ui/issues/621