### PR TITLE
(fix) Removed drag-thumb handler

### DIFF
--- a/src/ui/Scrollbars/Scrollbars.js
+++ b/src/ui/Scrollbars/Scrollbars.js
@@ -6,12 +6,15 @@ import 'react-perfect-scrollbar/dist/css/styles.css'
 
 import './style.css'
 
+const scrollbarOptions = {
+  minScrollbarLength: 25,
+  maxScrollbarLength: 100,
+  handlers: ['click-rail', 'keyboard', 'wheel', 'touch'],
+}
+
 const Scrollbars = ({ children, ...rest }) => (
   <PerfectScrollbar
-    options={{
-      minScrollbarLength: 25,
-      maxScrollbarLength: 100,
-    }}
+    options={scrollbarOptions}
     {...rest}
   >
     {children}


### PR DESCRIPTION
ticket - https://app.asana.com/0/1125859137800433/1201311029469895

I removed drag-thumb scrollbar listener. Now user can't click and move scrollbar. Ivan approved solution. But I think we need to find another scrollbar component

https://user-images.githubusercontent.com/81973123/143458326-a276b20a-1043-446a-8ac6-e8e86796fbd6.mp4

