### PR TITLE
(improvement) Live strategy exec: show margin checkbox only to pairs that support it

### DIFF
--- a/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
+++ b/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
@@ -4,6 +4,7 @@ import { Checkbox } from '@ufx-ui/core'
 import PropTypes from 'prop-types'
 import _find from 'lodash/find'
 import _isEmpty from 'lodash/isEmpty'
+import _includes from 'lodash/includes'
 
 import Button from '../../ui/Button'
 import AmountInput from '../OrderForm/FieldComponents/input.amount'
@@ -85,7 +86,7 @@ const LiveStrategyExecutor = ({
         </div>
       </div>
       <div className='hfui-backtester_row'>
-        {!isPaperTrading && (
+        {!isPaperTrading && _includes(symbol?.contexts, 'm') && (
           <div className='hfui-backtester__flex_start'>
             <Checkbox
               label={t('strategyEditor.useMarginCheckbox')}


### PR DESCRIPTION
ASANA Ticket: [[improvement] Live strategy execution: show margin checkbox only to pairs that support it](https://app.asana.com/0/1125859137800433/1201473733538362/f)

UI Demonstration:
![Screenshot from 2021-12-06 15-33-27](https://user-images.githubusercontent.com/35810911/144855079-e0b048f8-9f67-4713-96bc-056465ac928c.png)
![Screenshot from 2021-12-06 15-33-40](https://user-images.githubusercontent.com/35810911/144855088-fd468ada-2704-4ad6-a080-836e7afbd9cf.png)

