### PR TITLE
(improvement) Live strategy execution notifications

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -372,6 +372,8 @@
     "orderPartiallyFilledBuyDetailed": "{{exID}} {{type}} BUY order of {{amount}} {{symbol}} partially filled (ID: {{id}})",
     "orderPartiallyFilledSellAtDetailed": "{{exID}} {{type}} SELL order of {{amount}} {{symbol}} partially filled at {{price}} (ID: {{id}})",
     "orderPartiallyFilledSellDetailed": "{{exID}} {{type}} SELL order of {{amount}} {{symbol}} partially filled (ID: {{id}})",
+    "startedLiveStrategyExecution": "Started live strategy execution ({{name}}) for {{symbol}}-{{tf}}",
+    "stoppedLiveStrategyExecution": "Stopped live strategy execution ({{name}}) for {{symbol}}-{{tf}}",
     "stoppedAO": "Stopped algo order",
     "startedAO": "Started AO {{name}} on {{target}}",
     "unknownAlgoOrderId": "Unknown algo order ID: {{aoID}}",

--- a/src/redux/middleware/ws/on_message.js
+++ b/src/redux/middleware/ws/on_message.js
@@ -1,6 +1,7 @@
 import _isArray from 'lodash/isArray'
 import _isObject from 'lodash/isObject'
 import _isNumber from 'lodash/isNumber'
+import _isEmpty from 'lodash/isEmpty'
 import _reduce from 'lodash/reduce'
 import _map from 'lodash/map'
 import Debug from 'debug'
@@ -415,7 +416,11 @@ export default (alias, store) => (e = {}) => {
         } else {
           store.dispatch(WSActions.stopLiveExecution())
         }
-        store.dispatch(WSActions.setExecutionOptions(options))
+
+        if (!_isEmpty(options)) {
+          store.dispatch(WSActions.setExecutionOptions(options))
+        }
+
         store.dispatch(WSActions.setExecutionLoading(false))
 
         break


### PR DESCRIPTION
Required by:
 - https://github.com/bitfinexcom/bfx-hf-server/pull/137

Changes:
 - added support for new notifications related to live strategy execution
 - do not reset strategy if the provided options at `strategy.live_execution_status` are empty