### PR TITLE
(fix) Blank screen on hosted when auth token is invalid

### DIFF
--- a/src/redux/config.js
+++ b/src/redux/config.js
@@ -27,6 +27,8 @@ const appVersion = process.env.npm_package_version
 
 const CHART_URL = isElectronApp ? 'https://hchart.bitfinex.com/v0' : process.env.REACT_APP_CHART_URL
 
+const HONEY_AUTH_URL = `${process.env.REACT_APP_UFX_API_URL}/honey`
+
 export {
   REDUCER_PATHS,
   PUB_REST_API_URL,
@@ -35,4 +37,5 @@ export {
   appVersion,
   env,
   CHART_URL,
+  HONEY_AUTH_URL,
 }

--- a/src/redux/middleware/ws/on_message.js
+++ b/src/redux/middleware/ws/on_message.js
@@ -17,6 +17,7 @@ import closeElectronApp from '../../helpers/close_electron_app'
 import { MAIN_MODE, PAPER_MODE } from '../../reducers/ui'
 import tokenStore from '../../../util/token_store'
 import { AOAdapter } from '../../adapters/ws'
+import { isElectronApp } from '../../config'
 
 const debug = Debug('hfui:rx:m:ws-hfui-server:msg')
 
@@ -86,6 +87,16 @@ export default (alias, store) => (e = {}) => {
       case 'auth.token': {
         const [, tokenObj] = payload
         tokenStore.set(tokenObj?.authToken)
+        break
+      }
+
+      case 'auth.failure': { // WIP: waiting for a similar event to be introduced at the backend side
+        // if the authorisation token on hosted app is not valid, redirect to a page where it will be updated
+        if (!isElectronApp) {
+          const authURL = `${process.env.REACT_APP_UFX_API_URL}/honey`
+          window.location.replace(authURL) // eslint-disable-line lodash/prefer-lodash-method
+        }
+
         break
       }
 

--- a/src/redux/middleware/ws/on_message.js
+++ b/src/redux/middleware/ws/on_message.js
@@ -17,7 +17,7 @@ import closeElectronApp from '../../helpers/close_electron_app'
 import { MAIN_MODE, PAPER_MODE } from '../../reducers/ui'
 import tokenStore from '../../../util/token_store'
 import { AOAdapter } from '../../adapters/ws'
-import { isElectronApp } from '../../config'
+import { isElectronApp, HONEY_AUTH_URL } from '../../config'
 
 const debug = Debug('hfui:rx:m:ws-hfui-server:msg')
 
@@ -93,8 +93,7 @@ export default (alias, store) => (e = {}) => {
       case 'auth.failure': { // WIP: waiting for a similar event to be introduced at the backend side
         // if the authorisation token on hosted app is not valid, redirect to a page where it will be updated
         if (!isElectronApp) {
-          const authURL = `${process.env.REACT_APP_UFX_API_URL}/honey`
-          window.location.replace(authURL) // eslint-disable-line lodash/prefer-lodash-method
+          window.location.replace(HONEY_AUTH_URL) // eslint-disable-line lodash/prefer-lodash-method
         }
 
         break

--- a/src/redux/middleware/ws/on_message.js
+++ b/src/redux/middleware/ws/on_message.js
@@ -90,7 +90,7 @@ export default (alias, store) => (e = {}) => {
         break
       }
 
-      case 'auth.failure': { // WIP: waiting for a similar event to be introduced at the backend side
+      case 'auth.failure': {
         // if the authorisation token on hosted app is not valid, redirect to a page where it will be updated
         if (!isElectronApp) {
           window.location.replace(HONEY_AUTH_URL) // eslint-disable-line lodash/prefer-lodash-method


### PR DESCRIPTION
ASANA Ticket: [[bug] After logout and opening hosted version again, it shows and empty page due to invalid token cookie](https://app.asana.com/0/1125859137800433/1201492677277140/f)

Related to:
 - https://github.com/bitfinexcom/bfx-hf-hosted/pull/72