### PR TITLE
(fix) Overlapping AO Actions on Trading State panel

### DIFF
--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
@@ -35,8 +35,8 @@ export default (authToken, cancelOrder, gaCancelOrder, t, getMarketPair, editOrd
   cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.label),
 }, {
   dataKey: 'cid',
-  width: 80,
-  flexGrow: 0.8,
+  width: 50,
+  minWidth: 50,
   cellRenderer: ({ rowData = {} }) => ( // eslint-disable-line
     <div className='icons-cell'>
       <Icon

--- a/src/components/GridLayout/GridLayout.helpers.js
+++ b/src/components/GridLayout/GridLayout.helpers.js
@@ -86,7 +86,7 @@ export const COMPONENT_DIMENSIONS = {
     w: 40, h: 6, minW: 21, minH: 5,
   },
   [COMPONENT_TYPES.TRADING_STATE_PANEL]: {
-    w: 40, h: 6, minW: 32, minH: 5,
+    w: 40, h: 6, minW: 35, minH: 5,
   },
   [COMPONENT_TYPES.EXCHANGE_INFO_BAR]: {
     w: 20, h: 8, minW: 20, minH: 4,

--- a/src/redux/reducers/ui/default_layout_trading.js
+++ b/src/redux/reducers/ui/default_layout_trading.js
@@ -53,7 +53,7 @@ export default {
     }, {
       w: 49,
       h: 10,
-      minW: 32,
+      minW: 35,
       minH: 5,
       x: 26,
       y: 11,


### PR DESCRIPTION
ASANA Ticket: [[bug] AO actions are overlapping on small screens](https://app.asana.com/0/1125859137800433/1201497262442352/f)

UI Demonstration:
![Screenshot from 2021-12-10 11-20-26](https://user-images.githubusercontent.com/35810911/145549621-0f434bc4-1635-4d48-a48b-abba94daeaa7.png)

