### PR TITLE
(improvement): DatePicker: added i18n supporing

### DIFF
--- a/src/components/OrderForm/FieldComponents/input.checkbox.js
+++ b/src/components/OrderForm/FieldComponents/input.checkbox.js
@@ -32,7 +32,7 @@ CheckboxInput.displayName = 'CheckboxInput'
 CheckboxInput.propTypes = {
   id: PropTypes.string.isRequired,
   def: PropTypes.objectOf(PropTypes.oneOfType([
-    PropTypes.string, PropTypes.bool,
+    PropTypes.string, PropTypes.bool, PropTypes.array,
   ])).isRequired,
   renderData: PropTypes.shape({
     QUOTE: PropTypes.string.isRequired,

--- a/src/components/OrderForm/FieldComponents/input.date.js
+++ b/src/components/OrderForm/FieldComponents/input.date.js
@@ -2,19 +2,25 @@ import React, { memo } from 'react'
 import DatePicker from 'react-datepicker'
 import PropTypes from 'prop-types'
 
+import { useSelector } from 'react-redux'
 import { renderString, CONVERT_LABELS_TO_PLACEHOLDERS } from './fields.helpers'
+import { LANGUAGES } from '../../../locales/i18n'
+import { getCurrentLanguage } from '../../../redux/selectors/ui'
+import { getLocalDateFormat } from '../../../util/date'
 
 const DateInput = ({
   value, minDate, maxDate, onChange, def, renderData, validationError,
 }) => {
   const { label, minDate: MIN_DATE } = def
   const renderedLabel = renderString(label, renderData)
+  const currentLanguage = useSelector(getCurrentLanguage)
+
   return (
     <div className='hfui-orderform__input fullWidth hfui-input'>
       <DatePicker
         width='100%'
         popperPlacement='bottom-start'
-        dateFormat='MMMM d, yyyy h:mm aa'
+        dateFormat={getLocalDateFormat(LANGUAGES[currentLanguage])}
         timeCaption='Time'
         timeFormat='HH:mm'
         dropdownMode='select'
@@ -27,6 +33,7 @@ const DateInput = ({
         maxDate={maxDate}
         onChange={onChange}
         placeholder={CONVERT_LABELS_TO_PLACEHOLDERS ? renderedLabel : undefined}
+        locale={LANGUAGES[currentLanguage]}
       />
 
       {!CONVERT_LABELS_TO_PLACEHOLDERS && (

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -5,6 +5,10 @@ import i18n from 'i18next'
 import backend from 'i18next-xhr-backend'
 import detector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
+import {
+  ru, es, tr, zhCN, zhTW, enUS,
+} from 'date-fns/locale'
+import { registerLocale } from 'react-datepicker'
 
 const { REACT_APP_ENV } = process.env
 
@@ -34,6 +38,13 @@ export const LANGUAGES_CHART_TABLE = {
   cn: 'zh',
   tw: 'zh_TW',
 }
+
+registerLocale(LANGUAGES.en, enUS)
+registerLocale(LANGUAGES.ru, ru)
+registerLocale(LANGUAGES.es, es)
+registerLocale(LANGUAGES.tr, tr)
+registerLocale(LANGUAGES.tw, zhTW)
+registerLocale(LANGUAGES.cn, zhCN)
 
 export const LOCAL_STORAGE_I18N_KEY = 'HF_LOCALE'
 

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -1,3 +1,19 @@
 import { isValid } from 'date-fns'
+import { LANGUAGES } from '../locales/i18n'
 
 export const isValidDate = (date) => isValid(new Date(date))
+
+export const getLocalDateFormat = (lang) => {
+  switch (lang) {
+    case LANGUAGES.ru:
+    case LANGUAGES.tr:
+    case LANGUAGES.es:
+      return 'd MMMM yyyy, HH:MM'
+    case LANGUAGES.cn:
+    case LANGUAGES.tw:
+      return 'yyyy MMMM d, HH:MM'
+
+    default:
+      return 'MMMM d, yyyy h:mm aa'
+  }
+}


### PR DESCRIPTION
ticket - https://app.asana.com/0/1125859137800433/1201491731143913

Now DatePicker component is supporting i18n, including local date format 
![Снимок экрана от 2021-12-10 15-09-25](https://user-images.githubusercontent.com/81973123/145579948-4ad2efa5-98a0-4c27-ae43-7d46c334bff0.png)
![Снимок экрана от 2021-12-10 15-11-25](https://user-images.githubusercontent.com/81973123/145579949-6320d6e1-8254-417a-8591-b4b6cefefb0c.png)
![Снимок экрана от 2021-12-10 15-11-43](https://user-images.githubusercontent.com/81973123/145579950-6a33b1b2-ee1f-447b-934d-5d824da70f89.png)
![Снимок экрана от 2021-12-10 15-12-05](https://user-images.githubusercontent.com/81973123/145579953-7ba84bb5-ed78-45de-9837-a55ba34b52d7.png)
![Снимок экрана от 2021-12-10 15-14-41](https://user-images.githubusercontent.com/81973123/145579955-afe65db5-a97e-488f-a2b8-ae159a0ce74c.png)

