### PR TITLE
(improvement) disable margin trading if a new pair does not support it

### DIFF
--- a/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
+++ b/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
@@ -66,6 +66,9 @@ const LiveStrategyExecutor = ({
             value={symbol}
             onChange={(selection) => {
               const sel = _find(markets, m => m.wsID === selection.wsID)
+              if (!_includes(sel?.contexts, 'm')) {
+                setMargin(false)
+              }
               setSymbol(sel)
             }}
             markets={markets}


### PR DESCRIPTION
ASANA Ticket: [[improvement] Live strategy execution: show margin checkbox only to pairs that support it](https://app.asana.com/0/0/1201473733538362/1201506879168715/f)

When changing pairs, setting margin trading checkbox to `false` if the updated pair does not support it.