### PR TITLE
(fix) multilingual support of edit atomic orders

### DIFF
--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Icon } from 'react-fa'
+import _isEmpty from 'lodash/isEmpty'
 
 import { defaultCellRenderer } from '../../util/ui'
 
@@ -44,16 +45,18 @@ export default (authToken, cancelOrder, gaCancelOrder, t, getMarketPair, editOrd
         aria-label='Edit order'
         onClick={() => editOrder(rowData)}
       />
-      <i
-        role='button'
-        aria-label='Cancel order'
-        tabIndex={0}
-        className='icon-cancel'
-        onClick={() => {
-          cancelOrder(authToken, rowData)
-          gaCancelOrder()
-        }}
-      />
+      {!_isEmpty(rowData?.id) && (
+        <i
+          role='button'
+          aria-label='Cancel order'
+          tabIndex={0}
+          className='icon-cancel'
+          onClick={() => {
+            cancelOrder(authToken, rowData)
+            gaCancelOrder()
+          }}
+        />
+      )}
     </div>
   ),
   disableSort: true,

--- a/src/modals/EditOrderModal/EditOrderModal.js
+++ b/src/modals/EditOrderModal/EditOrderModal.js
@@ -74,7 +74,8 @@ const EditOrderModal = ({
     const updOrder = { ...order }
     const algoOrders = getAOs(t)
     let isAlgoOrder = true
-    let uiDef = _find(algoOrders, ({ label }) => label === updOrder.name)
+    let uiDef = _find(algoOrders, ({ id }) => id === updOrder.id)
+
     if (!uiDef) {
       const orders = getAtomicOrders(t)
       const processedType = _replace(_toLower(updOrder.type), /(exchange )/i, '')

--- a/src/modals/EditOrderModal/EditOrderModal.js
+++ b/src/modals/EditOrderModal/EditOrderModal.js
@@ -75,11 +75,10 @@ const EditOrderModal = ({
     const algoOrders = getAOs(t)
     let isAlgoOrder = true
     let uiDef = _find(algoOrders, ({ label }) => label === updOrder.name)
-
     if (!uiDef) {
       const orders = getAtomicOrders(t)
       const processedType = _replace(_toLower(updOrder.type), /(exchange )/i, '')
-      uiDef = _find(orders, ({ label }) => _toLower(label) === processedType)
+      uiDef = _find(orders, ({ id }) => id === processedType)
       isAlgoOrder = false
     }
 

--- a/src/orders/fok.js
+++ b/src/orders/fok.js
@@ -2,6 +2,7 @@ export default (t) => ({
   label: t('orderForm.fokTitle'),
   customHelp: t('orderForm.fokHelp'),
   uiIcon: 'fill-or-kill-active',
+  id: 'fill or kill',
 
   generateOrder: (data = {}, symbol, context) => {
     const {

--- a/src/orders/ioc.js
+++ b/src/orders/ioc.js
@@ -2,6 +2,7 @@ export default (t) => ({
   label: t('orderForm.iocTitle'),
   customHelp: t('orderForm.iocHelp'),
   uiIcon: 'immediate-or-cancel-active',
+  id: 'immediate or cancel',
 
   generateOrder: (data = {}, symbol, context) => {
     const {

--- a/src/orders/limit.js
+++ b/src/orders/limit.js
@@ -4,6 +4,7 @@ export default (t) => ({
   label: t('orderForm.limitTitle'),
   uiIcon: 'limit-active',
   customHelp: t('orderForm.limitHelp'),
+  id: 'limit',
 
   generateOrder: (data = {}, symbol, context) => {
     const {

--- a/src/orders/market.js
+++ b/src/orders/market.js
@@ -4,6 +4,7 @@ export default (t = () => {}) => ({
   label: t('orderForm.marketTitle'),
   uiIcon: 'market-active',
   customHelp: t('orderForm.marketHelp'),
+  id: 'market',
 
   generateOrder: (data = {}, symbol, context) => {
     const { reduceonly, amount, lev } = data

--- a/src/orders/stop.js
+++ b/src/orders/stop.js
@@ -4,6 +4,7 @@ export default (t) => ({
   label: t('orderForm.stopTitle'),
   uiIcon: 'stop-active',
   customHelp: t('orderForm.stopHelp'),
+  id: 'stop',
 
   generateOrder: (data = {}, symbol, context) => {
     const {

--- a/src/orders/stop_limit.js
+++ b/src/orders/stop_limit.js
@@ -4,6 +4,7 @@ export default (t) => ({
   label: t('orderForm.stopLimitTitle'),
   uiIcon: 'stop-limit-active',
   customHelp: t('orderForm.stopLimitHelp'),
+  id: 'stop limit',
 
   generateOrder: (data = {}, symbol, context) => {
     const {

--- a/src/orders/trailing_stop.js
+++ b/src/orders/trailing_stop.js
@@ -4,6 +4,7 @@ export default (t) => ({
   label: t('orderForm.trailingStopTitle'),
   uiIcon: 'trailing-stop-active',
   customHelp: t('orderForm.trailingStopHelp'),
+  id: 'trailing stop',
 
   generateOrder: (data = {}, symbol, context) => {
     const {


### PR DESCRIPTION
ASANA Ticket: [[BUG]: non English edit order will be empty](https://app.asana.com/0/1125859137800433/1201515436025957/f)

Depends on:
 - https://github.com/bitfinexcom/bfx-hf-server/pull/138

UI Demonstration:
![Screenshot from 2021-12-14 20-00-28](https://user-images.githubusercontent.com/35810911/146054126-8f567c4a-c2c1-46c6-b70d-0236c56eca04.png)
![Screenshot from 2021-12-15 11-28-14](https://user-images.githubusercontent.com/35810911/146160058-e59d810c-1fec-4071-9ea3-463c990b6487.png)

