### PR TITLE
(fix) overlapping atomic cancel button issue

### DIFF
--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -76,8 +76,8 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPa
   cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.status),
 }, {
   dataKey: 'cid',
-  width: 40,
-  flexGrow: 0.4,
+  width: 50,
+  minWidth: 50,
   cellRenderer: ({ rowData = {} }) => ( // eslint-disable-line
     <div className='icons-cell'>
       <Icon


### PR DESCRIPTION
ASANA Ticket: [[bug] Atomic Order overlapping 'cancel' button](https://app.asana.com/0/1125859137800433/1201519664384409/f)

UI Demonstration:
Before:
![Screenshot from 2021-12-15 21-13-53](https://user-images.githubusercontent.com/35810911/146250746-4f07ca54-84f5-42bc-a3cd-25155e75b2c0.png)

After:
![Screenshot from 2021-12-15 21-15-34](https://user-images.githubusercontent.com/35810911/146250762-ed14256d-cbcf-4e0e-8bd6-b032e0d387ec.png)
