### PR TITLE
(improvement) atomic order status/type

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -445,6 +445,7 @@
     "margin": "Margin",
     "derivatives": "Derivatives",
     "fokTitle": "Fill or Kill",
+    "hidden": "Hidden",
     "visibleOnHit": "Visible on hit",
     "visibleOnHitHelp": "The rest part of the hidden order will be visible after first hit (partial execution).",
     "fokHelp": "An FOK order is a limit order that must fully fill immediately or it is canceled (killed).",

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -1,18 +1,22 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/display-name */
 import React from 'react'
-import { PrettyValue } from '@ufx-ui/core'
+import { PrettyValue, Tooltip } from '@ufx-ui/core'
 import { Icon } from 'react-fa'
 
 import { defaultCellRenderer } from '../../util/ui'
+import { orderContext } from '../../util/order'
 import { AMOUNT_DECIMALS, PRICE_SIG_FIGS } from '../../constants/precision'
 
 const STYLES = {
   amount: { justifyContent: 'flex-end' },
   price: { justifyContent: 'flex-end' },
+  status: { display: 'flex', flexDirection: 'row' },
+  statusText: { width: '30px' },
+  statusIcon: { width: '60px' },
 }
 
-export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPair, editOrder) => [{
+export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPair, editOrder, getIsDerivativePair) => [{
   label: '',
   dataKey: '',
   width: 15,
@@ -32,7 +36,7 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPa
   dataKey: 'type',
   width: 120,
   flexGrow: 1.2,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.type),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(orderContext(rowData, getIsDerivativePair)),
 }, {
   label: t('table.created'),
   dataKey: 'created',
@@ -73,7 +77,40 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPa
   dataKey: 'status',
   width: 100,
   flexGrow: 1,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(rowData.status),
+  cellRenderer: ({ rowData = {} }) => (
+    <div style={STYLES.status} className='order-status'>
+      <div style={STYLES.statusText}>
+        {defaultCellRenderer(rowData.status)}
+      </div>
+      <div style={STYLES.statusIcon}>
+        {rowData.hidden && !rowData.visibleOnHit && (
+          <Tooltip content={t('orderForm.hidden')}>
+            <Icon name='eye-slash' className='icon-status' />
+          </Tooltip>
+        )}
+        {rowData.hidden && rowData.visibleOnHit && (
+          <Tooltip content={t('orderForm.visibleOnHit')}>
+            <Icon name='eye-slash' />
+          </Tooltip>
+        )}
+        {rowData.tif && (
+          <Tooltip content={new Date(rowData.tif).toLocaleString()}>
+            <Icon name='clock-o' />
+          </Tooltip>
+        )}
+        {rowData.postonly && (
+          <Tooltip content={t('orderForm.postOnlyCheckbox')}>
+            <Icon name='info' />
+          </Tooltip>
+        )}
+        {rowData.reduceonly && (
+          <Tooltip content={t('orderForm.reduceOnlyCheckbox')}>
+            <Icon name='info-circle' />
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  ),
 }, {
   dataKey: 'cid',
   width: 50,

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.container.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import Debug from 'debug'
 
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import { getAuthToken, getAtomicOrders, getFilteredAtomicOrders } from '../../redux/selectors/ws'
 import { getMarketPair } from '../../redux/selectors/meta'
 import WSActions from '../../redux/actions/ws'
@@ -9,6 +10,8 @@ import UIActions from '../../redux/actions/ui'
 
 import AtomicOrdersTable from './AtomicOrdersTable'
 
+const { getIsDerivativePair } = reduxSelectors
+
 const debug = Debug('hfui:c:atomic-orders-table')
 
 const mapStateToProps = (state = {}, { activeFilter }) => ({
@@ -16,6 +19,7 @@ const mapStateToProps = (state = {}, { activeFilter }) => ({
   filteredAtomicOrders: getFilteredAtomicOrders(state)(activeFilter),
   atomicOrders: getAtomicOrders(state),
   getMarketPair: getMarketPair(state),
+  getIsDerivativePair: getIsDerivativePair(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -10,14 +10,15 @@ import './style.css'
 
 const AtomicOrdersTable = ({
   atomicOrders, filteredAtomicOrders, renderedInTradingState,
-  cancelOrder, authToken, gaCancelOrder, getMarketPair, editOrder,
+  cancelOrder, authToken, gaCancelOrder, getMarketPair, editOrder, getIsDerivativePair,
 }) => {
   const [ref, size] = useSize()
   const data = renderedInTradingState ? filteredAtomicOrders : atomicOrders
+  console.log('data: ', data)
   const { t } = useTranslation()
   const columns = useMemo(
-    () => AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t, getMarketPair, editOrder),
-    [authToken, cancelOrder, gaCancelOrder, getMarketPair, size, t, editOrder],
+    () => AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t, getMarketPair, editOrder, getIsDerivativePair),
+    [authToken, cancelOrder, gaCancelOrder, getMarketPair, size, t, editOrder, getIsDerivativePair],
   )
 
   return (
@@ -45,6 +46,7 @@ AtomicOrdersTable.propTypes = {
   gaCancelOrder: PropTypes.func.isRequired,
   editOrder: PropTypes.func.isRequired,
   renderedInTradingState: PropTypes.bool,
+  getIsDerivativePair: PropTypes.func.isRequired,
 }
 
 AtomicOrdersTable.defaultProps = {

--- a/src/components/AtomicOrdersTable/style.scss
+++ b/src/components/AtomicOrdersTable/style.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import "../../variables.scss";
 
 .hfui-orderstable__wrapper {
   padding-bottom: 8px;
@@ -12,15 +12,21 @@
     display: flex;
     justify-content: space-around;
     align-items: center;
-  
+
     > * {
       margin-right: 8px;
       font-size: 16px;
-    
+
       &:hover {
         cursor: pointer;
         color: var(--shade-7);
       }
+    }
+  }
+
+  .order-status {
+    span.fa {
+      margin-left: 5px;
     }
   }
 }

--- a/src/util/order.js
+++ b/src/util/order.js
@@ -1,3 +1,23 @@
+import _includes from 'lodash/includes'
+import _replace from 'lodash/replace'
+
+export const ORDER_CONTEXT = {
+  EXCHANGE: 'EXCHANGE',
+  MARGIN: 'MARGIN',
+  DERIVATIVE: 'DERIVATIVE',
+}
+
+export const orderContext = ({ type, symbol, oco }, isDerivativePair) => {
+  const prefix = (oco) ? 'OCO ' : ''
+  const isExchange = _includes(type, 'EXCHANGE')
+  const _type = prefix + _replace(type, 'EXCHANGE', '')
+  if (isDerivativePair(symbol)) return `${ORDER_CONTEXT.DERIVATIVE} ${_type}`
+
+  return isExchange
+    ? `${ORDER_CONTEXT.EXCHANGE} ${_type}`
+    : `${ORDER_CONTEXT.MARGIN} ${_type}`
+}
+
 export const getAOContext = (rowData) => {
-  return rowData?.args?._futures ? 'Derivative' : rowData?.args?._margin ? 'Margin' : 'Exchange'
+  return rowData?.args?._futures ? ORDER_CONTEXT.DERIVATIVE : rowData?.args?._margin ? ORDER_CONTEXT.MARGIN : ORDER_CONTEXT.EXCHANGE
 }


### PR DESCRIPTION
Depends on: https://github.com/bitfinexcom/bfx-hf-server/pull/139

[[Improvement] Add status icons for 'Hidden' (visible on hit), 'Time in Force', and 'Reduce Only' similar to the web UI](https://app.asana.com/0/1125859137800433/1201506879168698/f)

- show order context for atomic orders
- show hidden/tif/reduceonly/postonly icon with status