### PR TITLE
(fix) incorrect initial value of languages dropdown

### DIFF
--- a/src/components/Navbar/Navbar.LanguageSettings.js
+++ b/src/components/Navbar/Navbar.LanguageSettings.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import _keys from 'lodash/keys'
 import _map from 'lodash/map'
+import _findKey from 'lodash/findKey'
 
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -16,6 +17,12 @@ const LanguageSettings = () => {
   const { i18n } = useTranslation()
   const language = useSelector(getCurrentLanguage)
   const dispatch = useDispatch()
+  const i18nLang = i18n.language
+  const i18nMappedLang = _findKey(LANGUAGES, (value) => value === i18nLang)
+
+  useEffect(() => {
+    dispatch(UIActions.setLanguage(i18nMappedLang))
+  }, [dispatch, i18nMappedLang])
 
   const changeLanguageHandler = (lang) => {
     i18n.changeLanguage(LANGUAGES[lang])


### PR DESCRIPTION
[[Translation] sync language with bitfinex SPA](https://app.asana.com/0/0/1201060240309477/f)

Fix issue: 
1. visit https://bfx-hf-ui-core.staging.bitfinex.com/, set some lang i.e. Spanish
2. visit https://bfx-ui-api.staging.bitfinex.com , change language to Russian
3. visit https://bfx-hf-ui-core.staging.bitfinex.com/ with Try Now link, content is in Russian language but language dropdown is showing stale value i.e. Spanish in this case