### PR TITLE
(fix) Trading State Panel small screen overlapping

### DIFF
--- a/src/components/GridLayout/GridLayout.helpers.js
+++ b/src/components/GridLayout/GridLayout.helpers.js
@@ -86,7 +86,7 @@ export const COMPONENT_DIMENSIONS = {
     w: 40, h: 6, minW: 21, minH: 5,
   },
   [COMPONENT_TYPES.TRADING_STATE_PANEL]: {
-    w: 40, h: 6, minW: 35, minH: 5,
+    w: 40, h: 6, minW: 40, minH: 5,
   },
   [COMPONENT_TYPES.EXCHANGE_INFO_BAR]: {
     w: 20, h: 8, minW: 20, minH: 4,

--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -12,7 +12,7 @@ import { getLocation } from '../../redux/selectors/router'
 import {
   removeComponent, changeLayout, setLayoutID, storeUnsavedLayout,
 } from '../../redux/actions/ui'
-import { renderLayoutElement } from './GridLayout.helpers'
+import { renderLayoutElement, COMPONENT_DIMENSIONS } from './GridLayout.helpers'
 import './style.css'
 
 import {
@@ -73,7 +73,11 @@ const GridLayout = ({
     sharedProps,
   }
 
-  const currentLayouts = _get(layoutDef, 'layout', [])
+  const currentLayouts = _map(_get(layoutDef, 'layout', []), (layout) => ({
+    ...layout,
+    minW: COMPONENT_DIMENSIONS[layout?.c].minW,
+    minH: COMPONENT_DIMENSIONS[layout?.c].minH,
+  }))
   const onRemoveComponent = (i) => dispatch(removeComponent(i))
 
   /* fix-start: initial grid rendering issue

--- a/src/redux/reducers/ui/default_layout_trading.js
+++ b/src/redux/reducers/ui/default_layout_trading.js
@@ -53,7 +53,7 @@ export default {
     }, {
       w: 49,
       h: 10,
-      minW: 35,
+      minW: 40,
       minH: 5,
       x: 26,
       y: 11,

--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -27,6 +27,7 @@ import DEFAULT_MARKET_DATA_COMPONENT_STATE from './default_component_state_marke
 import DEFAULT_ACTIVE_MARKET_STATE from './default_active_market_state'
 
 import {
+  COMPONENT_DIMENSIONS,
   DEFAULT_TRADING_KEY,
   DEFAULT_MARKET_KEY,
   layoutDefToGridLayout,
@@ -480,6 +481,7 @@ function reducer(state = getInitialState(), action = {}) {
               c: component,
               x,
               y: y + 1,
+              ...COMPONENT_DIMENSIONS[component],
             },
           ],
         },

--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -27,7 +27,6 @@ import DEFAULT_MARKET_DATA_COMPONENT_STATE from './default_component_state_marke
 import DEFAULT_ACTIVE_MARKET_STATE from './default_active_market_state'
 
 import {
-  COMPONENT_DIMENSIONS,
   DEFAULT_TRADING_KEY,
   DEFAULT_MARKET_KEY,
   layoutDefToGridLayout,
@@ -481,7 +480,6 @@ function reducer(state = getInitialState(), action = {}) {
               c: component,
               x,
               y: y + 1,
-              ...COMPONENT_DIMENSIONS[component],
             },
           ],
         },


### PR DESCRIPTION
ASANA Ticket: [[bug] AO actions are overlapping on small screens](https://app.asana.com/0/1125859137800433/1201497262442352/f)

UI Demonstration:
![Screenshot from 2022-01-03 15-20-44](https://user-images.githubusercontent.com/35810911/147935214-eb4e1e32-0da6-496f-acd0-c39f82cc3869.png)

