### PR TITLE
(improvement) Localise order type and status fields

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -631,5 +631,13 @@
     "text2_1": "Please, report this issue at",
     "text2_2": "so we would be able to fix it as soon as possible!",
     "text3": "Technical crash info"
+  },
+  "orderContexts": {
+    "exchange": "Exchange",
+    "margin": "Margin",
+    "funding": "Derivative"
+  },
+  "orderStatuses": {
+    "ACTIVE": "ACTIVE"
   }
 }

--- a/public/locales/ru-RU/translations.json
+++ b/public/locales/ru-RU/translations.json
@@ -610,13 +610,5 @@
     "removeBtn": "Удалить",
     "createBtn": "Создать",
     "startBtn": "Начать"
-  },
-  "orderContexts": {
-    "exchange": "Обменный",
-    "margin": "Маржинальный",
-    "funding": "Дериватив"
-  },
-  "orderStatuses": {
-    "ACTIVE": "АКТИВНЫЙ"
   }
 }

--- a/public/locales/ru-RU/translations.json
+++ b/public/locales/ru-RU/translations.json
@@ -610,5 +610,13 @@
     "removeBtn": "Удалить",
     "createBtn": "Создать",
     "startBtn": "Начать"
+  },
+  "orderContexts": {
+    "exchange": "Обменный",
+    "margin": "Маржинальный",
+    "funding": "Дериватив"
+  },
+  "orderStatuses": {
+    "ACTIVE": "АКТИВНЫЙ"
   }
 }

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -13,11 +13,11 @@ const STYLES = {
   amount: { justifyContent: 'flex-end' },
   price: { justifyContent: 'flex-end' },
   status: { display: 'flex', flexDirection: 'row' },
-  statusText: { width: '30px' },
-  statusIcon: { width: '60px' },
+  statusText: { width: '50px' },
+  statusIcon: { width: '10px' },
 }
 
-export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPair, editOrder, getIsDerivativePair) => [{
+export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPair, editOrder, getIsDerivativePair, orders) => [{
   label: '',
   dataKey: '',
   width: 15,
@@ -37,18 +37,18 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPa
   dataKey: 'type',
   width: 120,
   flexGrow: 1.2,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(orderContext(rowData, getIsDerivativePair)),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(orderContext(rowData, getIsDerivativePair, t, orders)),
 }, {
   label: t('table.created'),
   dataKey: 'created',
-  width: 145,
-  flexGrow: 1.5,
+  width: 135,
+  flexGrow: 1.35,
   cellRenderer: ({ rowData = {} }) => defaultCellRenderer(new Date(+rowData.created).toLocaleString()),
 }, {
   label: t('table.amount'),
   dataKey: 'amount',
-  width: 120,
-  flexGrow: 1.2,
+  width: 110,
+  flexGrow: 1.1,
   headerStyle: STYLES.amount,
   style: STYLES.amount,
   cellRenderer: ({ rowData = {} }) => defaultCellRenderer(
@@ -62,8 +62,8 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPa
 }, {
   label: t('table.price'),
   dataKey: 'price',
-  width: 120,
-  flexGrow: 1.2,
+  width: 100,
+  flexGrow: 1,
   headerStyle: STYLES.price,
   style: STYLES.price,
   cellRenderer: ({ rowData = {} }) => defaultCellRenderer(
@@ -76,12 +76,12 @@ export default (authToken, cancelOrder, gaCancelOrder, { width }, t, getMarketPa
 }, {
   label: t('table.status'),
   dataKey: 'status',
-  width: 100,
-  flexGrow: 1,
+  width: 120,
+  flexGrow: 1.2,
   cellRenderer: ({ rowData = {} }) => (
     <div style={STYLES.status} className='order-status'>
       <div style={STYLES.statusText}>
-        {defaultCellRenderer(rowData.status)}
+        {defaultCellRenderer(t(`orderStatuses.${rowData.status}`))}
       </div>
       <div style={STYLES.statusIcon}>
         {rowData.hidden && !rowData.visibleOnHit && (

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import { VirtualTable } from '@ufx-ui/core'
 import { useTranslation } from 'react-i18next'
+import { getAtomicOrders } from '../OrderForm/OrderForm.orders.helpers'
 
 import useSize from '../../hooks/useSize'
 import AtomicOrdersTableColumns from './AtomicOrdersTable.columns'
@@ -15,9 +16,10 @@ const AtomicOrdersTable = ({
   const [ref, size] = useSize()
   const data = renderedInTradingState ? filteredAtomicOrders : atomicOrders
   const { t } = useTranslation()
+  const orders = getAtomicOrders(t)
   const columns = useMemo(
-    () => AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t, getMarketPair, editOrder, getIsDerivativePair),
-    [authToken, cancelOrder, gaCancelOrder, getMarketPair, size, t, editOrder, getIsDerivativePair],
+    () => AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size, t, getMarketPair, editOrder, getIsDerivativePair, orders),
+    [authToken, cancelOrder, gaCancelOrder, getMarketPair, size, t, editOrder, getIsDerivativePair, orders],
   )
 
   return (

--- a/src/components/BalancesTable/BalancesTable.columns.js
+++ b/src/components/BalancesTable/BalancesTable.columns.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/display-name */
 import React from 'react'
-import _capitalize from 'lodash/capitalize'
 import { PrettyValue } from '@ufx-ui/core'
 import { defaultCellRenderer } from '../../util/ui'
 import { AMOUNT_DECIMALS } from '../../constants/precision'
@@ -16,7 +15,7 @@ export default (t) => [{
   dataKey: 'context',
   width: 120,
   flexGrow: 1,
-  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(_capitalize(rowData.context)),
+  cellRenderer: ({ rowData = {} }) => defaultCellRenderer(t(`orderContexts.${rowData.context}`)),
 }, {
   label: t('table.currency'),
   dataKey: 'symbol',

--- a/src/ui/PanelSettings/PanelSettings.js
+++ b/src/ui/PanelSettings/PanelSettings.js
@@ -12,7 +12,11 @@ const PanelSettings = ({
   const { t } = useTranslation()
   return (
     <div className='hfui-panelsettings__wrapper'>
-      {title && (<p className='header'>{title}</p>)}
+      {title || (
+        <p className='header'>
+          {t('appSettings.title')}
+        </p>
+      )}
       {content && (
         <div className={ClassNames('inner')}>{content}</div>
       )}
@@ -34,7 +38,7 @@ PanelSettings.propTypes = {
 }
 
 PanelSettings.defaultProps = {
-  title: 'Settings',
+  title: null,
   onClose: () => { },
 }
 

--- a/src/util/order.js
+++ b/src/util/order.js
@@ -1,5 +1,8 @@
 import _includes from 'lodash/includes'
 import _replace from 'lodash/replace'
+import _toLower from 'lodash/toLower'
+import _toUpper from 'lodash/toUpper'
+import _find from 'lodash/find'
 
 export const ORDER_CONTEXT = {
   EXCHANGE: 'EXCHANGE',
@@ -7,15 +10,19 @@ export const ORDER_CONTEXT = {
   DERIVATIVE: 'DERIVATIVE',
 }
 
-export const orderContext = ({ type, symbol, oco }, isDerivativePair) => {
-  const prefix = (oco) ? 'OCO ' : ''
-  const isExchange = _includes(type, 'EXCHANGE')
-  const _type = prefix + _replace(type, 'EXCHANGE', '')
-  if (isDerivativePair(symbol)) return `${ORDER_CONTEXT.DERIVATIVE} ${_type}`
+export const orderContext = ({
+  type, symbol, oco,
+}, isDerivativePair, t, orders) => {
+  const prefix = oco ? 'OCO ' : ''
+  const isExchange = _includes(type, ORDER_CONTEXT.EXCHANGE)
+  const _type = _replace(_toLower(type), /(exchange )/i, '')
+  let { label } = _find(orders, ({ id }) => id === _type) || { label: _type }
+  label = `${prefix}${label}`
 
+  if (isDerivativePair(symbol)) return _toUpper(`${t('orderContexts.funding')} ${label}`)
   return isExchange
-    ? `${ORDER_CONTEXT.EXCHANGE} ${_type}`
-    : `${ORDER_CONTEXT.MARGIN} ${_type}`
+    ? _toUpper(`${t('orderContexts.exchange')} ${label}`)
+    : _toUpper(`${t('orderContexts.margin')} ${label}`)
 }
 
 export const getAOContext = (rowData) => {


### PR DESCRIPTION
ASANA Ticket: [Localise order type and status fields](https://app.asana.com/0/1125859137800433/1201536145792788/f)
Changelog:
 - added localisation for Atomic Orders and Balances components
 - translation 'settings' for PanelSettings component

UI Demonstration:
![Screenshot from 2022-01-10 13-22-08](https://user-images.githubusercontent.com/35810911/148758228-058eaa0b-1f3a-4bb0-927b-23f06ed97dc6.png)
![Screenshot from 2022-01-10 13-21-58](https://user-images.githubusercontent.com/35810911/148758220-27485776-d36c-40f2-8e1d-7e56edb06140.png)

