### PR TITLE
(fix) Atomic order close issue

### DIFF
--- a/src/redux/reducers/ws/order_history.js
+++ b/src/redux/reducers/ws/order_history.js
@@ -9,7 +9,7 @@ export default (state = getInitialState(), action = {}) => {
 
   switch (type) {
     case types.DATA_ORDER_CLOSE: {
-      const { order = [] } = payload
+      const { order = {} } = payload
       return [
         order,
         ...state,

--- a/src/redux/reducers/ws/orders.js
+++ b/src/redux/reducers/ws/orders.js
@@ -34,10 +34,9 @@ export default (state = getInitialState(), action = {}) => {
     }
 
     case types.DATA_ORDER_CLOSE: {
-      const { order = [] } = payload
-      const adapted = orderAdapter(order)
+      const { order = {} } = payload
 
-      return _omit(state, adapted?.id)
+      return _omit(state, order?.id)
     }
 
     case types.DEAUTH: {


### PR DESCRIPTION
ASANA Tickets:
[[BUG] edit algo (pingPong or Iceberg) will not remove non-relevant atomic orders](https://app.asana.com/0/1125859137800433/1201644136974580/f)
[[BUG] when limit order is executed, it will not be removed from atomic order table](https://app.asana.com/0/1125859137800433/1201645280222511/f)