### PR TITLE
(fix) DatePicker: fix calendar overlapping tif input, style improvements

### DIFF
--- a/src/components/Backtester/forms/HistoricalForm.js
+++ b/src/components/Backtester/forms/HistoricalForm.js
@@ -116,7 +116,7 @@ const HistoricalForm = ({
             onChange={val => setFormState(() => ({ startDate: val }))}
             def={{ label: t('strategyEditor.startDate') }}
             value={startDate}
-            maxDate={MAX_DATE}
+            maxDate={endDate}
           />
         </div>
         <div className='hfui-backtester_dateInput hfui-backtester__flex_start'>
@@ -125,6 +125,7 @@ const HistoricalForm = ({
             def={{ label: t('strategyEditor.endDate') }}
             value={endDate}
             maxDate={MAX_DATE}
+            minDate={startDate}
           />
         </div>
         <div>

--- a/src/components/OrderForm/FieldComponents/input.date.js
+++ b/src/components/OrderForm/FieldComponents/input.date.js
@@ -86,7 +86,7 @@ DateInput.propTypes = {
 }
 
 DateInput.defaultProps = {
-  minDate: new Date('01-01-2009'),
+  minDate: new Date('01/01/2009'),
   maxDate: null,
   renderData: {},
   validationError: '',

--- a/src/components/OrderForm/FieldComponents/input.date.js
+++ b/src/components/OrderForm/FieldComponents/input.date.js
@@ -3,6 +3,7 @@ import DatePicker from 'react-datepicker'
 import PropTypes from 'prop-types'
 
 import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 import { renderString, CONVERT_LABELS_TO_PLACEHOLDERS } from './fields.helpers'
 import { LANGUAGES } from '../../../locales/i18n'
 import { getCurrentLanguage } from '../../../redux/selectors/ui'
@@ -15,13 +16,15 @@ const DateInput = ({
   const renderedLabel = renderString(label, renderData)
   const currentLanguage = useSelector(getCurrentLanguage)
 
+  const { t } = useTranslation()
+
   return (
     <div className='hfui-orderform__input fullWidth hfui-input'>
       <DatePicker
         width='100%'
         popperPlacement='bottom-start'
         dateFormat={getLocalDateFormat(LANGUAGES[currentLanguage])}
-        timeCaption='Time'
+        timeCaption={t('table.time')}
         timeFormat='HH:mm'
         dropdownMode='select'
         showTimeSelect

--- a/src/components/OrderForm/FieldComponents/input.date.js
+++ b/src/components/OrderForm/FieldComponents/input.date.js
@@ -34,6 +34,7 @@ const DateInput = ({
         onChange={onChange}
         placeholder={CONVERT_LABELS_TO_PLACEHOLDERS ? renderedLabel : undefined}
         locale={LANGUAGES[currentLanguage]}
+        calendarClassName='hfui-datepicker'
       />
 
       {!CONVERT_LABELS_TO_PLACEHOLDERS && (

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -1,10 +1,14 @@
 @import "../../variables.scss";
 
 .hfui-orderform__wrapper {
+  .react-datepicker__tab-loop {
+    position: relative;
+  }
+
   .react-datepicker-popper {
     left: -2px;
-    transform: translate3d(0px, 231px, 0px) !important;
-    margin-top: 35px;
+    transform: translate(0px, 5px) !important;
+    margin-top: 0px;
     margin-left: 15px;
   }
 
@@ -331,6 +335,10 @@
   display: inline-block;
   vertical-align: middle;
   margin: 0 0 16px 0;
+
+  .hfui-datepicker{
+    border: 1px solid $black-color;
+  }
 
   input[type="range"] {
     width: 100%;

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -336,8 +336,21 @@
   vertical-align: middle;
   margin: 0 0 16px 0;
 
-  .hfui-datepicker{
+  .hfui-datepicker {
     border: 1px solid $black-color;
+
+    .react-datepicker__day--disabled {
+      color: $grey-color;
+    }
+    .react-datepicker__month-select,
+    .react-datepicker__year-select {
+      border: 1px solid $grey-color;
+      padding: 3px;
+      font-weight: 500;
+    }
+    .react-datepicker-time__header {
+      font-weight: 500;
+    }
   }
 
   input[type="range"] {


### PR DESCRIPTION
ticket - https://app.asana.com/0/1125859137800433/1201638056468672

-date picker is positioned relative to the date input, not order form wrapper
-added border color, because it blends into the background of parent component
-added translation for Time title
-avoid 'Invalid time period' error in Backtest - set minDate for end time input, which is startDate and maxDate for start time input, which is endDate
-improved some styles: removed ugly dropdown borders and bold font, added visualization of disabled status 

![Снимок экрана от 2022-01-12 10-17-52](https://user-images.githubusercontent.com/81973123/149089698-927d78a5-d332-4ed3-b9db-4b8dbb08edab.png)
![Снимок экрана от 2022-01-12 10-18-03](https://user-images.githubusercontent.com/81973123/149089701-d9f3acad-9505-4daf-89f8-9cced2921dc9.png)

style improvements:
![Снимок экрана от 2022-01-12 10-45-34](https://user-images.githubusercontent.com/81973123/149093857-cfbc844f-59df-4716-b615-d20391b667dc.png)


