### PR TITLE
(feature) add component to show when app update is available

### DIFF
--- a/src/components/AppUpdate/AppUpdate.js
+++ b/src/components/AppUpdate/AppUpdate.js
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from 'react'
+import cx from 'clsx'
+import _isFunction from 'lodash/isFunction'
+import { isElectronApp } from '../../redux/config'
+
+import './style.css'
+
+// @TODO: i18n
+function AppUpdate() {
+  const [hideNotification, setHideNotification] = useState(true)
+  const [hideRestart, setHideRestart] = useState(true)
+  const [message, setMessage] = useState('')
+
+  // init state
+  useEffect(() => {
+    setHideNotification(true)
+    setHideRestart(true)
+    setMessage('')
+  }, [])
+
+  const onUpdateAvailable = () => {
+    setMessage('A new update is available. Downloading now...')
+    setHideNotification(false)
+  }
+
+  // eslint-disable-next-line
+  const onUpdateDownloaded = (_event, releaseNotes, releaseName) => {
+    setMessage('Update Downloaded. It will be installed on restart. Restart now?')
+    setHideRestart(false)
+    setHideNotification(false)
+  }
+
+  useEffect(() => {
+    if (_isFunction(window.require) && isElectronApp) {
+      const electron = window.require('electron')
+      const { ipcRenderer } = electron
+
+      ipcRenderer.on('update_available', onUpdateAvailable)
+      ipcRenderer.on('update_downloaded', onUpdateDownloaded)
+
+      return () => {
+        ipcRenderer.removeListener('update_available', onUpdateAvailable)
+        ipcRenderer.removeListener('update_downloaded', onUpdateDownloaded)
+      }
+    }
+
+    return () => {} // consistent-return
+  }, [])
+
+  const closeNotification = () => {
+    setHideNotification(true)
+    if (_isFunction(window.require)) {
+      const electron = window.require('electron')
+      const { ipcRenderer } = electron
+      ipcRenderer.send('clear_app_update_timer')
+    }
+  }
+
+  const restartApp = () => {
+    if (_isFunction(window.require)) {
+      const electron = window.require('electron')
+      const { ipcRenderer } = electron
+      ipcRenderer.send('restart_app')
+    }
+  }
+
+  return (
+    <div
+      className={cx('hfui-app-update__notification', { hidden: hideNotification })}
+    >
+      <p className='message'>{message}</p>
+      <div className='btn-group'>
+        <button
+          className='close-button'
+          type='button'
+          onClick={closeNotification}
+        >
+          Close
+        </button>
+        <button
+          className={cx('restart', {
+            hidden: hideRestart,
+          })}
+          type='button'
+          onClick={restartApp}
+        >
+          Restart
+        </button>
+      </div>
+    </div>
+  )
+}
+
+AppUpdate.propTypes = { }
+
+export default AppUpdate

--- a/src/components/AppUpdate/AppUpdate.js
+++ b/src/components/AppUpdate/AppUpdate.js
@@ -11,13 +11,6 @@ function AppUpdate() {
   const [hideRestart, setHideRestart] = useState(true)
   const [message, setMessage] = useState('')
 
-  // init state
-  useEffect(() => {
-    setHideNotification(true)
-    setHideRestart(true)
-    setMessage('')
-  }, [])
-
   const onUpdateAvailable = () => {
     setMessage('A new update is available. Downloading now...')
     setHideNotification(false)

--- a/src/components/AppUpdate/index.js
+++ b/src/components/AppUpdate/index.js
@@ -1,0 +1,1 @@
+export { default } from './AppUpdate'

--- a/src/components/AppUpdate/style.scss
+++ b/src/components/AppUpdate/style.scss
@@ -1,0 +1,25 @@
+hfui-app-update__notification {
+  position: fixed;
+  bottom: 40px;
+  left: 15px;
+  width: 240px;
+  padding: 20px;
+  border-radius: 5px;
+  background-color: var(--shade-1);
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+
+  &.hidden,
+  .hidden {
+    display: none;
+  }
+
+  .btn-group {
+    margin-top: 10px;
+    display: flex;
+    justify-content: space-evenly;
+  }
+
+  button {
+    padding: 5px 10px;
+  }
+}

--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -12,6 +12,7 @@ import { THEMES, SETTINGS } from '../../redux/selectors/ui'
 import useInjectBfxData from '../../hooks/useInjectBfxData'
 import StrategyEditorPage from '../../pages/StrategyEditor'
 import NotificationsSidebar from '../NotificationsSidebar'
+import AppUpdate from '../AppUpdate'
 import closeElectronApp from '../../redux/helpers/close_electron_app'
 import Routes from '../../constants/routes'
 import { isElectronApp } from '../../redux/config'
@@ -150,6 +151,7 @@ const HFUI = (props) => {
         </>
       )}
       <NotificationsSidebar notificationsVisible={notificationsVisible} />
+      {isElectronApp && <AppUpdate />}
     </Suspense>
   )
 }


### PR DESCRIPTION
Note: This component is hidden, until app-update-notify support is added to bfx-hf-ui, hence it's safe to merge now.