### PR TITLE
(fix) Mobile screen component headers overlaps

### DIFF
--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -97,7 +97,7 @@ const GridLayout = ({
   */
   useEffect(() => {
     if (mounted) {
-      setTimeout(() => { window.dispatchEvent(new Event('resize')) }, 100)
+      setTimeout(() => { window.dispatchEvent(new Event('resize')) }, 200)
     }
   }, [mounted])
   /* fix-end: initial grid rendering issue */

--- a/src/ui/Panel/style.scss
+++ b/src/ui/Panel/style.scss
@@ -81,6 +81,7 @@
   background: var(--background-color);
   justify-content: space-between;
   padding: spacing(0.5) spacing(0.5) spacing(0.5) spacing(1);
+  flex-wrap: wrap;
 
   &.has-secondary-header {
     border-bottom: none;


### PR DESCRIPTION
ASANA Ticket: [[BUG] Hosted mobile layout: Trading state panel is overlapping Filter buy](https://app.asana.com/0/1125859137800433/1201699832205770/f)

UI Demonstration:
![Screenshot from 2022-01-24 18-20-05](https://user-images.githubusercontent.com/35810911/150822340-1eb8b340-fd08-4d3e-a434-4aec31bb6269.png)

