### PR TITLE
DMS toggle should not open active AO modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui-core",
-  "version": "3.26.0",
+  "version": "3.26.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4478,6 +4478,20 @@
         "lodash": "^4.17.15"
       },
       "dependencies": {
+        "bfx-api-node-core": {
+          "version": "git+https://github.com/bitfinexcom/bfx-api-node-core.git#b014959d2d61f0036b67258c57c22a7815b77913",
+          "from": "git+https://github.com/bitfinexcom/bfx-api-node-core.git#v1.5.6",
+          "requires": {
+            "bfx-api-node-models": "git+https://github.com/bitfinexcom/bfx-api-node-models.git#v1.6.2",
+            "bfx-api-node-rest": "^4.1.2",
+            "bfx-api-node-util": "^1.0.10",
+            "bfx-api-node-ws1": "^1.0.3",
+            "bluebird": "^3.7.2",
+            "debug": "^4.3.1",
+            "lodash": "^4.17.21",
+            "ws": "^8.2.1"
+          }
+        },
         "bfx-api-node-models": {
           "version": "git+https://github.com/bitfinexcom/bfx-api-node-models.git#d8b5f1751afb4aa92ba593c8ef3360cd8339d176",
           "from": "git+https://github.com/bitfinexcom/bfx-api-node-models.git#v1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui-core",
-  "version": "3.26.0",
+  "version": "3.26.1",
   "description": "Web based Honey Framework UI - for live trading and executing algorithmic orders and strategies",
   "engines": {
     "node": ">=6"

--- a/src/modals/AppSettingsModal/AppSettingsModal.General.js
+++ b/src/modals/AppSettingsModal/AppSettingsModal.General.js
@@ -11,7 +11,6 @@ import Dropdown from '../../ui/Dropdown'
 import WSActions from '../../redux/actions/ws'
 import GAActions from '../../redux/actions/google_analytics'
 import UIActions from '../../redux/actions/ui'
-import { getActiveAlgoOrders } from '../../redux/actions/ao'
 import {
   isDevEnv,
   getAutoLoginState,
@@ -69,7 +68,6 @@ const General = () => {
     } else {
       setIsDmsChecked(nextDms)
       dispatch(WSActions.saveSettings(SETTINGS.DMS, nextDms))
-      dispatch(getActiveAlgoOrders())
       dispatch(GAActions.updateSettings())
     }
   }

--- a/src/modals/ConfirmDMSModal/ConfirmDMSModal.container.js
+++ b/src/modals/ConfirmDMSModal/ConfirmDMSModal.container.js
@@ -4,7 +4,6 @@ import UIActions from '../../redux/actions/ui'
 import GAActions from '../../redux/actions/google_analytics'
 import WSActions from '../../redux/actions/ws'
 import { getIsConfirmDMSModalVisible, SETTINGS } from '../../redux/selectors/ui'
-import { getActiveAlgoOrders } from '../../redux/actions/ao'
 
 import ConfirmDMSModal from './ConfirmDMSModal'
 
@@ -16,7 +15,6 @@ const mapDispatchToProps = dispatch => ({
   changeConfirmDMSModalState: (isVisible) => dispatch(UIActions.changeConfirmDMSModalState(isVisible)),
   changeDMSSetting: (nextDms) => {
     dispatch(WSActions.saveSettings(SETTINGS.DMS, nextDms))
-    dispatch(getActiveAlgoOrders())
     dispatch(GAActions.updateSettings())
   },
 })


### PR DESCRIPTION
In the previous implementation, when toggling the settings for the DMS, it caused a reconnection in the backend, so the UI would fetch the actives algo again and give the option to cancel or load them again. 

Now, we don't cause a reconnection, and showing this modal would only cause a duplicate of orders as the state is already loaded. 

PS: The modal is still required and triggered when reopening the app