### PR TITLE
(fix) Tickers have 0 volume after trading mode switch

### DIFF
--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -80,6 +80,7 @@ function getInitialState() {
     unsavedLayout: null,
     layoutID: null,
     tab: null,
+    tickersVolumeUnit: null,
   }
 
   if (!localStorage) {
@@ -134,7 +135,6 @@ function getInitialState() {
     }
 
     defaultState.layouts = nextFormatLayouts
-    defaultState.tickersVolumeUnit = isPaperTrading ? VOLUME_UNIT_PAPER.TESTUSD : VOLUME_UNIT.USD
   } catch (e) {
     debug('Loading layouts error, check localStorage: %s', LAYOUTS_KEY)
   }
@@ -390,6 +390,7 @@ function reducer(state = getInitialState(), action = {}) {
         ...state,
         isPaperTrading,
         currentMode: mode,
+        tickersVolumeUnit: isPaperTrading ? VOLUME_UNIT_PAPER.TESTUSD : VOLUME_UNIT.USD,
       }
     }
     case types.CHANGE_TRADING_MODAL_STATE: {


### PR DESCRIPTION
ASANA Ticket: [[BUG]TestUSD and volume 0 displayed on production](https://app.asana.com/0/1125859137800433/1201707950007871/f)

UI Demonstration:

https://user-images.githubusercontent.com/35810911/152784608-b8d91471-eddf-4720-a602-047540b1b4bd.mp4


