### PR TITLE
(fix) memory leak when switching pages

### DIFF
--- a/src/hooks/useTourGuide.js
+++ b/src/hooks/useTourGuide.js
@@ -6,9 +6,17 @@ const useTourGuide = (isGuideActive) => {
   // delay guide active status to avoid missing guide spotlight because of target not found error
   useEffect(() => {
     const delay = isGuideActive ? 500 : 0
+    let isMounted = true
+
     setTimeout(() => {
-      setIsGuideActiveLocal(isGuideActive)
+      if (isMounted) {
+        setIsGuideActiveLocal(isGuideActive)
+      }
     }, delay)
+
+    return () => {
+      isMounted = false
+    }
   }, [isGuideActive])
 
   return isGuideActiveLocal


### PR DESCRIPTION
ASANA Ticket: [[bug] useTourGuide memory leak](https://app.asana.com/0/1125859137800433/1201785976206083/f)

The memory leak message could be reproduced by quickly switching from one page to another.
![Screenshot from 2022-02-08 20-30-01](https://user-images.githubusercontent.com/35810911/153054867-4cdc33e6-0286-425e-a34c-2e82a807984b.png)

UI Demonstration:
![Screenshot from 2022-02-08 20-41-09](https://user-images.githubusercontent.com/35810911/153054623-9e3d3820-5b10-423d-8923-34714ac383f5.png)

