### PR TITLE
(improvement) Display strategy execution fees as a red negative number

### DIFF
--- a/src/components/Backtester/Results/Results.js
+++ b/src/components/Backtester/Results/Results.js
@@ -54,17 +54,16 @@ const Results = ({ results }) => {
 
       <div key='results-right' className='hfui-strategyeditor__results-section'>
         <ul>
-          <ResultRow label={t('strategyEditor.fees')} value={resultNumber(preparePrice(fees), '$')} />
+          <ResultRow label={t('strategyEditor.fees')} value={resultNumber(preparePrice(-fees), '$')} />
           <ResultRow label={t('strategyEditor.profitLoss')} value={resultNumber(preparePrice(pl), '$')} />
-          {hasTrades
-            && (
-              <>
-                <ResultRow label={t('strategyEditor.profitFactor')} value={resultNumber(pf, '', 2, false)} />
-                <ResultRow label={t('strategyEditor.volume')} value={resultNumber(vol, '$')} />
-                <ResultRow label={t('strategyEditor.largestGain')} value={resultNumber(preparePrice(maxPL), '$')} />
-                <ResultRow label={t('strategyEditor.largestLoss')} value={resultNumber(preparePrice(minPL), '$')} />
-              </>
-            )}
+          {hasTrades && (
+            <>
+              <ResultRow label={t('strategyEditor.profitFactor')} value={resultNumber(pf, '', 2, false)} />
+              <ResultRow label={t('strategyEditor.volume')} value={resultNumber(vol, '$')} />
+              <ResultRow label={t('strategyEditor.largestGain')} value={resultNumber(preparePrice(maxPL), '$')} />
+              <ResultRow label={t('strategyEditor.largestLoss')} value={resultNumber(preparePrice(minPL), '$')} />
+            </>
+          )}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
ASANA Ticket: [Strategy Result fees should be displayed as red negative number](https://app.asana.com/0/1125859137800433/1201829278900195/f)

UI Demonstration:
![Screenshot from 2022-02-15 15-11-01](https://user-images.githubusercontent.com/35810911/154068674-67ca7778-ad6b-4ff4-9510-4df02ea3755c.png)

