### PR TITLE
(improvement) Backtest: showing results in quote ccy

### DIFF
--- a/src/components/Backtester/Results/Results.js
+++ b/src/components/Backtester/Results/Results.js
@@ -1,40 +1,32 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
+import { getPairParts } from '@ufx-ui/utils'
 import { useTranslation } from 'react-i18next'
 
 import { preparePrice } from 'bfx-api-node-util'
 import ResultRow from './ResultRow'
 import ResultHeader from './ResultHeader'
+import { resultNumber } from './Results.utils'
 
 import './style.css'
-
-const resultNumber = (value, prefix = '', maxDecimals = 2, color = true) => {
-  let val = Number(Number(value).toFixed(maxDecimals))
-  if (Number.isNaN(val)) {
-    val = 0
-  }
-  const valueString = val.toLocaleString()
-  if (Number(value) < 0) {
-    return <span style={{ color: color ? 'red' : '' }}>{prefix + valueString}</span>
-  }
-  return <span style={{ color: color ? 'green' : '' }}>{prefix + valueString}</span>
-}
 
 const Results = ({ results }) => {
   const {
     nCandles, nTrades, nGains, nLosses, nStrategyTrades, nOpens, pl, pf,
-    maxPL, minPL, fees, vol, stdDeviation, avgPL,
+    maxPL, minPL, fees, vol, stdDeviation, avgPL, backtestOptions: { activeMarket },
   } = results
   const hasTrades = !!vol
+
+  const [, quoteCcy] = getPairParts(activeMarket)
   const { t } = useTranslation()
 
   return (
     <div className='hfui-strategyeditor__results-wrapper'>
       <div className='hfui-strategyeditor__results-header'>
-        <ResultHeader label={t('strategyEditor.totalPL')} value={resultNumber(preparePrice(pl), '$')} />
-        <ResultHeader label={t('strategyEditor.avgPL')} value={resultNumber(avgPL, '$', 2)} />
-        <ResultHeader label={t('strategyEditor.profitFactor')} value={resultNumber(pf, '', 2, false)} />
-        <ResultHeader label={t('strategyEditor.volatility')} value={resultNumber(stdDeviation, '', 2, false)} />
+        <ResultHeader label={t('strategyEditor.totalPL')} value={resultNumber(preparePrice(pl), quoteCcy)} />
+        <ResultHeader label={t('strategyEditor.avgPL')} value={resultNumber(avgPL, quoteCcy)} />
+        <ResultHeader label={t('strategyEditor.profitFactor')} value={resultNumber(pf)} />
+        <ResultHeader label={t('strategyEditor.volatility')} value={resultNumber(stdDeviation)} />
       </div>
       <div key='results-left' className='hfui-strategyeditor__results-section'>
         <ul>
@@ -54,14 +46,14 @@ const Results = ({ results }) => {
 
       <div key='results-right' className='hfui-strategyeditor__results-section'>
         <ul>
-          <ResultRow label={t('strategyEditor.fees')} value={resultNumber(preparePrice(-fees), '$')} />
-          <ResultRow label={t('strategyEditor.profitLoss')} value={resultNumber(preparePrice(pl), '$')} />
+          <ResultRow label={t('strategyEditor.fees')} value={resultNumber(preparePrice(-fees), quoteCcy)} />
+          <ResultRow label={t('strategyEditor.profitLoss')} value={resultNumber(preparePrice(pl), quoteCcy)} />
           {hasTrades && (
             <>
-              <ResultRow label={t('strategyEditor.profitFactor')} value={resultNumber(pf, '', 2, false)} />
-              <ResultRow label={t('strategyEditor.volume')} value={resultNumber(vol, '$')} />
-              <ResultRow label={t('strategyEditor.largestGain')} value={resultNumber(preparePrice(maxPL), '$')} />
-              <ResultRow label={t('strategyEditor.largestLoss')} value={resultNumber(preparePrice(minPL), '$')} />
+              <ResultRow label={t('strategyEditor.profitFactor')} value={resultNumber(pf)} />
+              <ResultRow label={t('strategyEditor.volume')} value={resultNumber(vol, quoteCcy)} />
+              <ResultRow label={t('strategyEditor.largestGain')} value={resultNumber(preparePrice(maxPL), quoteCcy)} />
+              <ResultRow label={t('strategyEditor.largestLoss')} value={resultNumber(preparePrice(minPL), quoteCcy)} />
             </>
           )}
         </ul>
@@ -86,6 +78,9 @@ Results.propTypes = {
     vol: PropTypes.number,
     stdDeviation: PropTypes.number,
     avgPL: PropTypes.number,
+    backtestOptions: PropTypes.shape({
+      activeMarket: PropTypes.string,
+    }).isRequired,
   }),
 }
 

--- a/src/components/Backtester/Results/Results.js
+++ b/src/components/Backtester/Results/Results.js
@@ -2,6 +2,8 @@ import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { getPairParts } from '@ufx-ui/utils'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 
 import { preparePrice } from 'bfx-api-node-util'
 import ResultRow from './ResultRow'
@@ -10,6 +12,8 @@ import { resultNumber } from './Results.utils'
 
 import './style.css'
 
+const { getCurrencySymbolMemo } = reduxSelectors
+
 const Results = ({ results }) => {
   const {
     nCandles, nTrades, nGains, nLosses, nStrategyTrades, nOpens, pl, pf,
@@ -17,7 +21,9 @@ const Results = ({ results }) => {
   } = results
   const hasTrades = !!vol
 
-  const [, quoteCcy] = getPairParts(activeMarket)
+  const [, quote] = getPairParts(activeMarket)
+  const getCurrencySymbol = useSelector(getCurrencySymbolMemo)
+  const quoteCcy = getCurrencySymbol(quote)
   const { t } = useTranslation()
 
   return (

--- a/src/components/Backtester/Results/Results.js
+++ b/src/components/Backtester/Results/Results.js
@@ -28,7 +28,7 @@ const Results = ({ results }) => {
         <ResultHeader label={t('strategyEditor.profitFactor')} value={resultNumber(pf)} />
         <ResultHeader label={t('strategyEditor.volatility')} value={resultNumber(stdDeviation)} />
       </div>
-      <div key='results-left' className='hfui-strategyeditor__results-section'>
+      <div key='results-left' className='hfui-strategyeditor__results-section results-left'>
         <ul>
           <ResultRow label={t('strategyEditor.backtestCandles')} value={nCandles} />
           <ResultRow label={t('strategyEditor.backtestTrades')} value={nTrades} />
@@ -44,7 +44,7 @@ const Results = ({ results }) => {
         </ul>
       </div>
 
-      <div key='results-right' className='hfui-strategyeditor__results-section'>
+      <div key='results-right' className='hfui-strategyeditor__results-section results-right'>
         <ul>
           <ResultRow label={t('strategyEditor.fees')} value={resultNumber(preparePrice(-fees), quoteCcy)} />
           <ResultRow label={t('strategyEditor.profitLoss')} value={resultNumber(preparePrice(pl), quoteCcy)} />

--- a/src/components/Backtester/Results/Results.utils.js
+++ b/src/components/Backtester/Results/Results.utils.js
@@ -12,6 +12,7 @@ const CRYPTO_MAX_DECIMALS = 8
 export const resultNumber = (value, ccy) => {
   const val = _toNumber(value)
   const isZero = val === 0
+  const isPositive = val > 0
 
   let maxDecimals = FIAT_MAX_DECIMALS
   const isCcyFiat = isFiat(ccy)
@@ -33,7 +34,9 @@ export const resultNumber = (value, ccy) => {
       ? decimalNumberString
       : isZero
         ? '0'
-        : '<0.01'
+        : isPositive
+          ? '<0.01'
+          : '>-0.01'
 
     return (
       <Tooltip content={decimalNumberWithoutRounded} placement='top'>
@@ -49,13 +52,13 @@ export const resultNumber = (value, ccy) => {
       ? `${quotePrefix}${decimalNumberString}`
       : isZero
         ? `${quotePrefix}0`
-        : `${quotePrefix}<0.01`
+        : isPositive ? `${quotePrefix}<0.01` : `${quotePrefix}>-0.01`
   } else {
     resultValueWithCcySign = Number(decimalNumberString)
       ? `${decimalNumberString} ${ccy}`
       : isZero
         ? `0 ${ccy}`
-        : `<0.00000001 ${ccy}`
+        : isPositive ? `<0.00000001 ${ccy}` : `>-0.00000001 ${ccy}`
   }
 
   if (roundedNumber <= 0) {

--- a/src/components/Backtester/Results/Results.utils.js
+++ b/src/components/Backtester/Results/Results.utils.js
@@ -1,0 +1,83 @@
+import React from 'react'
+
+import { isFiat } from '@ufx-ui/utils'
+import _toNumber from 'lodash/toNumber'
+import { Tooltip } from '@ufx-ui/core'
+import numberExponentToLarge from '../../../util/numberExponentToLarge'
+import getQuotePrefix from '../../../util/quote_prefix'
+
+const FIAT_MAX_DECIMALS = 2
+const CRYPTO_MAX_DECIMALS = 8
+
+export const resultNumber = (value, ccy) => {
+  const val = _toNumber(value)
+  const isZero = val === 0
+
+  let maxDecimals = FIAT_MAX_DECIMALS
+  const isCcyFiat = isFiat(ccy)
+
+  if (ccy) {
+    maxDecimals = isCcyFiat ? FIAT_MAX_DECIMALS : CRYPTO_MAX_DECIMALS
+  }
+  let roundedNumber = Number(val.toFixed(maxDecimals))
+
+  if (Number.isNaN(roundedNumber)) {
+    roundedNumber = 0
+  }
+
+  const decimalNumberString = numberExponentToLarge(roundedNumber)
+  const decimalNumberWithoutRounded = numberExponentToLarge(val)
+
+  if (!ccy) {
+    const nonCcyValue = Number(decimalNumberString)
+      ? decimalNumberString
+      : isZero
+        ? '0'
+        : '<0.01'
+
+    return (
+      <Tooltip content={decimalNumberWithoutRounded} placement='top'>
+        <span>{nonCcyValue}</span>
+      </Tooltip>
+    )
+  }
+  let resultValueWithCcySign = isCcyFiat
+
+  if (isCcyFiat) {
+    const quotePrefix = getQuotePrefix(ccy)
+    resultValueWithCcySign = Number(decimalNumberString)
+      ? `${quotePrefix}${decimalNumberString}`
+      : isZero
+        ? `${quotePrefix}0`
+        : `${quotePrefix}<0.01`
+  } else {
+    resultValueWithCcySign = Number(decimalNumberString)
+      ? `${decimalNumberString} ${ccy}`
+      : isZero
+        ? `0 ${ccy}`
+        : `<0.00000001 ${ccy}`
+  }
+
+  if (roundedNumber <= 0) {
+    return (
+      <Tooltip
+        content={
+          <span style={{ color: 'red' }}>{decimalNumberWithoutRounded}</span>
+        }
+        placement='top'
+      >
+        <span style={{ color: 'red' }}>{resultValueWithCcySign}</span>
+      </Tooltip>
+    )
+  }
+  return (
+    <Tooltip
+      content={
+        <span style={{ color: 'green' }}>{decimalNumberWithoutRounded}</span>
+      }
+      placement='top'
+    >
+      <span style={{ color: 'green' }}>{resultValueWithCcySign}</span>
+    </Tooltip>
+  )
+}

--- a/src/components/Backtester/Results/style.scss
+++ b/src/components/Backtester/Results/style.scss
@@ -72,12 +72,14 @@ body.hosted {
 
 .hfui-strategyeditor__results-header {
   display: flex;
+  flex-wrap: wrap;
   margin: 30px 0px;
 }
 
 .hfui-strategyeditor__results-header-item {
   flex: 1;
   white-space: nowrap;
+  margin-right: 10px;
 
   &:last-child > .hfui-strategyeditor__results-header-item_wrapper {
     margin-right: 0;
@@ -86,12 +88,12 @@ body.hosted {
 
 .hfui-strategyeditor__results-header-item_wrapper {
   display: block;
-  margin-right: 10px;
 
   p {
     color: $grey-color;
     font-size: 13px;
     line-height: 16px;
+    margin-bottom: 3px;
   }
 
   h4 {

--- a/src/components/Backtester/Results/style.scss
+++ b/src/components/Backtester/Results/style.scss
@@ -1,4 +1,4 @@
-@import '../../../variables.scss';
+@import "../../../variables.scss";
 
 body.hosted {
   @media screen and (max-width: 600px) {
@@ -36,6 +36,18 @@ body.hosted {
     text-align: center;
   }
 
+  .results-left {
+    p:first-child {
+      width: 70%;
+    }
+  }
+
+  .results-right {
+    p:first-child {
+      width: 50%;
+    }
+  }
+
   ul {
     font-size: 13px;
 
@@ -49,7 +61,6 @@ body.hosted {
       p:first-child {
         text-align: right;
         margin-right: 16px;
-        width: 50%;
       }
 
       > * {
@@ -65,8 +76,12 @@ body.hosted {
   padding: 6px;
 }
 
-.hfui-strategyeditor__results-section {
-  width: 50%;
+.hfui-strategyeditor__results-section.results-left {
+  width: 40%;
+  display: inline-block;
+}
+.hfui-strategyeditor__results-section.results-right {
+  width: 60%;
   display: inline-block;
 }
 
@@ -91,12 +106,12 @@ body.hosted {
 
   p {
     color: $grey-color;
-    font-size: 13px;
+    font-size: 12px;
     line-height: 16px;
     margin-bottom: 3px;
   }
 
   h4 {
-    font-size: 23px;
+    font-size: 19px;
   }
 }

--- a/src/util/numberExponentToLarge.js
+++ b/src/util/numberExponentToLarge.js
@@ -1,0 +1,49 @@
+/* eslint-disable */
+
+// https://codereview.stackexchange.com/questions/243164/convert-exponential-e-notation-numbers-to-decimals
+
+/** ******************************************************
+ * Converts Exponential (e-Notation) Numbers to Decimals
+ ********************************************************
+ * @function numberExponentToLarge()
+ * @version  1.00
+ * @param   {string}  Number in exponent format.
+ *                   (other formats returned as is).
+ * @return  {string}  Returns a decimal number string.
+ * @author  Mohsen Alyafei
+ * @date    12 Jan 2020
+ *
+ * Notes: No check is made for NaN or undefined inputs
+ *
+ ****************************************************** */
+
+function numberExponentToLarge(numIn) {
+  numIn += '' // To cater to numric entries
+  let sign = '' // To remember the number sign
+  numIn.charAt(0) == '-' && ((numIn = numIn.substring(1)), (sign = '-')) // remove - sign & remember it
+  let str = numIn.split(/[eE]/g) // Split numberic string at e or E
+  if (str.length < 2) return sign + numIn // Not an Exponent Number? Exit with orginal Num back
+  const power = str[1] // Get Exponent (Power) (could be + or -)
+  if (power == 0 || power == -0) return sign + str[0] // If 0 exponents (i.e. 0|-0|+0) then That's any easy one
+
+  const deciSp = (1.1).toLocaleString().substring(1, 2) // Get Deciaml Separator
+  str = str[0].split(deciSp) // Split the Base Number into LH and RH at the decimal point
+  let baseRH = str[1] || '' // RH Base part. Make sure we have a RH fraction else ""
+  let baseLH = str[0] // LH base part.
+
+  if (power > 0) {
+    // ------- Positive Exponents (Process the RH Base Part)
+    if (power > baseRH.length) baseRH += '0'.repeat(power - baseRH.length) // Pad with "0" at RH
+    baseRH = baseRH.slice(0, power) + deciSp + baseRH.slice(power) // Insert decSep at the correct place into RH base
+    if (baseRH.charAt(baseRH.length - 1) == deciSp) { baseRH = baseRH.slice(0, -1) } // If decSep at RH end? => remove it
+  } else {
+    // ------- Negative Exponents (Process the LH Base Part)
+    const num = Math.abs(power) - baseLH.length // Delta necessary 0's
+    if (num > 0) baseLH = '0'.repeat(num) + baseLH // Pad with "0" at LH
+    baseLH = baseLH.slice(0, power) + deciSp + baseLH.slice(power) // Insert "." at the correct place into LH base
+    if (baseLH.charAt(0) == deciSp) baseLH = `0${baseLH}` // If decSep at LH most? => add "0"
+  }
+  return sign + baseLH + baseRH // Return the long number (with sign)
+}
+
+export default numberExponentToLarge


### PR DESCRIPTION
tickets: 
- https://app.asana.com/0/1201848935859401/1201859021652325
- https://app.asana.com/0/1200372033300327/1201857915902843

- improved layout: added bottom margins for header titles, added flex wrap for header, because some titles can be hidden
- showing results in quote ccy
- rounding fiat and non-ccy values to 0.01, crypto - to 0.00000001
- showing <0.01 (>-0.01) for fiat/non-ccy values and <0.00000001 (>-0.00000001), showing 0 if value is 0
- added tooltip for rounded values

![Снимок экрана от 2022-02-22 17-58-30](https://user-images.githubusercontent.com/81973123/155178016-a7c20b10-f260-496c-b177-e262a3098cf7.png)
![Снимок экрана от 2022-02-22 18-29-34](https://user-images.githubusercontent.com/81973123/155178023-82766022-b8b0-4b90-a8b7-45449233cf14.png)
![Снимок экрана от 2022-02-22 18-29-24](https://user-images.githubusercontent.com/81973123/155178032-a2be2d55-f473-4a8b-bd73-875d4340e3b9.png)
![Снимок экрана от 2022-02-22 19-12-24](https://user-images.githubusercontent.com/81973123/155183164-79c99c71-91a7-4232-ac88-8998bdceb4a1.png)


