### PR TITLE
(fix) Revert "fixed prop-types errors"

### DIFF
--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.js
@@ -31,12 +31,8 @@ const AlgoOrdersTable = ({
 }
 
 AlgoOrdersTable.propTypes = {
-  algoOrders: PropTypes.objectOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.object,
-  ])),
-  filteredAlgoOrders: PropTypes.objectOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.object,
-  ])),
+  algoOrders: PropTypes.objectOf(PropTypes.object),
+  filteredAlgoOrders: PropTypes.objectOf(PropTypes.object),
   cancelOrder: PropTypes.func.isRequired,
   gaCancelOrder: PropTypes.func.isRequired,
   authToken: PropTypes.string.isRequired,

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -40,12 +40,8 @@ const AtomicOrdersTable = ({
 
 AtomicOrdersTable.propTypes = {
   authToken: PropTypes.string.isRequired,
-  atomicOrders: PropTypes.objectOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date),
-  ])),
-  filteredAtomicOrders: PropTypes.objectOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date),
-  ])),
+  atomicOrders: PropTypes.objectOf(PropTypes.object),
+  filteredAtomicOrders: PropTypes.objectOf(PropTypes.object),
   getMarketPair: PropTypes.func.isRequired,
   cancelOrder: PropTypes.func.isRequired,
   editOrder: PropTypes.func.isRequired,

--- a/src/components/Backtester/Backtester.js
+++ b/src/components/Backtester/Backtester.js
@@ -117,7 +117,7 @@ const Backtester = ({
 }
 
 Backtester.propTypes = {
-  indicators: PropTypes.arrayOf(PropTypes.array), // eslint-disable-line
+  indicators: PropTypes.arrayOf(PropTypes.array),
   backtest: PropTypes.shape({
     loading: PropTypes.bool.isRequired,
     executing: PropTypes.bool.isRequired,
@@ -132,9 +132,9 @@ Backtester.propTypes = {
       PropTypes.oneOf([null]).isRequired,
     ]),
   ),
-  markets: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
-  backtestResults: PropTypes.objectOf(PropTypes.any), // eslint-disable-line
-  backtestOptions: PropTypes.objectOf(PropTypes.any), // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object),
+  backtestResults: PropTypes.objectOf(PropTypes.any),
+  backtestOptions: PropTypes.objectOf(PropTypes.any),
   authToken: PropTypes.string.isRequired,
   dsExecuteBacktest: PropTypes.func.isRequired,
   setBacktestOptions: PropTypes.func.isRequired,

--- a/src/components/Backtester/forms/HistoricalForm.js
+++ b/src/components/Backtester/forms/HistoricalForm.js
@@ -174,7 +174,7 @@ HistoricalForm.propTypes = {
     trades: PropTypes.bool,
     candles: PropTypes.bool,
   }),
-  markets: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object),
   updateError: PropTypes.func.isRequired,
   setFormState: PropTypes.func.isRequired,
   backtestStrategy: PropTypes.func.isRequired,

--- a/src/components/BalancesTable/BalancesTable.js
+++ b/src/components/BalancesTable/BalancesTable.js
@@ -36,12 +36,8 @@ const BalancesTable = ({
 }
 
 BalancesTable.propTypes = {
-  balances: PropTypes.objectOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number,
-  ])),
-  filteredBalances: PropTypes.objectOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number,
-  ])),
+  balances: PropTypes.objectOf(PropTypes.object),
+  filteredBalances: PropTypes.objectOf(PropTypes.object),
   renderedInTradingState: PropTypes.bool,
   hideZeroBalances: PropTypes.bool,
 }

--- a/src/components/ChartPanel/ChartPanel.js
+++ b/src/components/ChartPanel/ChartPanel.js
@@ -95,7 +95,7 @@ ChartPanel.propTypes = {
       PropTypes.array, PropTypes.string, PropTypes.bool, PropTypes.number,
     ])),
   }),
-  markets: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object),
   getCurrencySymbol: PropTypes.func.isRequired,
   settingsTheme: PropTypes.oneOf([THEMES.LIGHT, THEMES.DARK]),
 }

--- a/src/components/ExchangeInfoBar/ExchangeInfoBar.js
+++ b/src/components/ExchangeInfoBar/ExchangeInfoBar.js
@@ -142,10 +142,8 @@ ExchangeInfoBar.propTypes = {
     changePerc: PropTypes.number,
     volumeConverted: PropTypes.number,
   }).isRequired,
-  markets: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
-  allTickersArray: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number,
-  ])).isRequired,
+  markets: PropTypes.objectOf(PropTypes.object),
+  allTickersArray: PropTypes.arrayOf(PropTypes.object).isRequired,
   favoritePairs: PropTypes.objectOf(PropTypes.bool).isRequired,
   updateFavorites: PropTypes.func.isRequired,
   authToken: PropTypes.string.isRequired,

--- a/src/components/GridLayout/GridLayout.js
+++ b/src/components/GridLayout/GridLayout.js
@@ -152,7 +152,7 @@ GridLayout.propTypes = {
   }),
   tradesProps: PropTypes.objectOf(PropTypes.bool),
   orderFormProps: PropTypes.shape({
-    orders: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line
+    orders: PropTypes.arrayOf(PropTypes.object),
   }),
   sharedProps: PropTypes.objectOf(PropTypes.oneOfType(
     [PropTypes.bool, PropTypes.string],

--- a/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
+++ b/src/components/LiveStrategyExecutor/LiveStrategyExecutor.js
@@ -164,7 +164,7 @@ const LiveStrategyExecutor = ({
 }
 
 LiveStrategyExecutor.propTypes = {
-  indicators: PropTypes.arrayOf(PropTypes.array), // eslint-disable-line
+  indicators: PropTypes.arrayOf(PropTypes.array),
   dsExecuteLiveStrategy: PropTypes.func.isRequired,
   dsStopLiveStrategy: PropTypes.func.isRequired,
   authToken: PropTypes.string.isRequired,
@@ -179,7 +179,7 @@ LiveStrategyExecutor.propTypes = {
       PropTypes.oneOf([null]).isRequired,
     ]),
   ),
-  markets: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object),
   isPaperTrading: PropTypes.bool.isRequired,
   theme: PropTypes.oneOf([THEMES.LIGHT, THEMES.DARK]),
   results: PropTypes.objectOf(PropTypes.oneOfType([

--- a/src/components/MarketSelect/MarketSelect.js
+++ b/src/components/MarketSelect/MarketSelect.js
@@ -125,7 +125,7 @@ const MarketSelect = forwardRef(function MarketSelect(props, ref) {
 MarketSelect.propTypes = {
   value: PropTypes.instanceOf(Object).isRequired,
   onChange: PropTypes.func.isRequired,
-  markets: PropTypes.objectOf(PropTypes.object).isRequired, // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object).isRequired,
   renderLabel: PropTypes.bool,
   className: PropTypes.instanceOf(Object),
   currentMode: PropTypes.string,

--- a/src/components/NotificationsSidebar/NotificationsSidebar.js
+++ b/src/components/NotificationsSidebar/NotificationsSidebar.js
@@ -80,9 +80,7 @@ const NotificationsSidebar = ({
 }
 
 NotificationsSidebar.propTypes = {
-  notifications: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number,
-  ])),
+  notifications: PropTypes.arrayOf(PropTypes.object).isRequired,
   removeNotifications: PropTypes.func.isRequired,
   clearNotifications: PropTypes.func.isRequired,
   closeNotificationPanel: PropTypes.func.isRequired,
@@ -92,7 +90,6 @@ NotificationsSidebar.propTypes = {
 
 NotificationsSidebar.defaultProps = {
   notificationsVisible: false,
-  notifications: [],
 }
 
 export default withTranslation()(memo(NotificationsSidebar))

--- a/src/components/NotificationsSidebar/SidebarContent.js
+++ b/src/components/NotificationsSidebar/SidebarContent.js
@@ -8,10 +8,16 @@ import Panel from '../../ui/Panel'
 import Button from '../../ui/Button'
 import Scrollbars from '../../ui/Scrollbars'
 
-function SidebarContent({
-  closeNotificationPanel, notifications, notificationsVisible, removeNotifications,
-  onClearNotifications, t,
-}) {
+function SidebarContent(props) {
+  const {
+    closeNotificationPanel,
+    notifications,
+    notificationsVisible,
+    removeNotifications,
+    onClearNotifications,
+    t,
+  } = props
+
   const onClose = useCallback(({ cid, group }) => {
     let cids = []
 
@@ -66,9 +72,7 @@ function SidebarContent({
 }
 
 SidebarContent.propTypes = {
-  notifications: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number,
-  ])),
+  notifications: PropTypes.arrayOf(PropTypes.object).isRequired,
   removeNotifications: PropTypes.func.isRequired,
   closeNotificationPanel: PropTypes.func.isRequired,
   onClearNotifications: PropTypes.func.isRequired,
@@ -78,7 +82,6 @@ SidebarContent.propTypes = {
 
 SidebarContent.defaultProps = {
   notificationsVisible: false,
-  notifications: [],
 }
 
 export default memo(SidebarContent)

--- a/src/components/OrderForm/FieldComponents/ui.ticker.js
+++ b/src/components/OrderForm/FieldComponents/ui.ticker.js
@@ -60,7 +60,7 @@ const TickerBar = (props) => {
 TickerBar.propTypes = {
   onFieldChange: PropTypes.func.isRequired,
   layout: PropTypes.shape({
-    fields: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
+    fields: PropTypes.objectOf(PropTypes.object),
   }).isRequired,
 }
 

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -564,7 +564,7 @@ OrderForm.propTypes = {
   mode: PropTypes.string.isRequired,
   submitAPIKeys: PropTypes.func.isRequired,
   getAlgoOrderParams: PropTypes.func.isRequired,
-  aoParams: PropTypes.objectOf(PropTypes.object).isRequired, // eslint-disable-line
+  aoParams: PropTypes.objectOf(PropTypes.object).isRequired,
   resetActiveAOParamsID: PropTypes.func.isRequired,
   submitOrder: PropTypes.func.isRequired,
   gaSubmitOrder: PropTypes.func.isRequired,

--- a/src/components/OrderForm/OrderFormMenu/OrderFormMenu.js
+++ b/src/components/OrderForm/OrderFormMenu/OrderFormMenu.js
@@ -35,12 +35,8 @@ const OrderFormMenu = ({ atomicOrderTypes, algoOrderTypes, onSelect }) => {
 }
 
 OrderFormMenu.propTypes = {
-  atomicOrderTypes: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string,
-  ])).isRequired,
-  algoOrderTypes: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string,
-  ])).isRequired,
+  atomicOrderTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  algoOrderTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
   onSelect: PropTypes.func.isRequired,
 }
 

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -40,9 +40,7 @@ const OrderHistory = ({
 }
 
 OrderHistory.propTypes = {
-  orders: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date),
-  ])),
+  orders: PropTypes.arrayOf(PropTypes.object),
   dark: PropTypes.bool,
   onRemove: PropTypes.func,
 }

--- a/src/components/PositionsTable/PositionsTable.js
+++ b/src/components/PositionsTable/PositionsTable.js
@@ -32,8 +32,8 @@ const PositionsTable = ({
 
 PositionsTable.propTypes = {
   setClosePositionModal: PropTypes.func.isRequired,
-  filteredPositions: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
-  positions: PropTypes.objectOf(PropTypes.object), // eslint-disable-line
+  filteredPositions: PropTypes.objectOf(PropTypes.object),
+  positions: PropTypes.objectOf(PropTypes.object),
   renderedInTradingState: PropTypes.bool,
   getMarketPair: PropTypes.func.isRequired,
 }

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -358,8 +358,8 @@ StrategyEditor.propTypes = {
       PropTypes.oneOf([null]).isRequired,
     ]),
   ),
-  strategies: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line
-  backtestResults: PropTypes.objectOf(PropTypes.any), // eslint-disable-line
+  strategies: PropTypes.arrayOf(PropTypes.object).isRequired,
+  backtestResults: PropTypes.objectOf(PropTypes.any),
   settingsTheme: PropTypes.oneOf([THEMES.LIGHT, THEMES.DARK]),
 }
 

--- a/src/components/StrategyEditor/components/StrategyEditorEmpty.js
+++ b/src/components/StrategyEditor/components/StrategyEditorEmpty.js
@@ -62,7 +62,7 @@ const EmptyContent = ({
 }
 
 EmptyContent.propTypes = {
-  strategies: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line
+  strategies: PropTypes.arrayOf(PropTypes.object).isRequired,
   openCreateNewStrategyModal: PropTypes.func.isRequired,
   openSelectExistingStrategyModal: PropTypes.func.isRequired,
   onOpen: PropTypes.func.isRequired,

--- a/src/components/StrategyEditor/components/StrategyEditorPanel.js
+++ b/src/components/StrategyEditor/components/StrategyEditorPanel.js
@@ -136,7 +136,7 @@ StrategyEditorPanel.propTypes = {
   onExportStrategy: PropTypes.func.isRequired,
   onImportStrategy: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
-  strategies: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line
+  strategies: PropTypes.arrayOf(PropTypes.object).isRequired,
 }
 
 StrategyEditorPanel.defaultProps = {

--- a/src/components/StrategyTradesTable/index.js
+++ b/src/components/StrategyTradesTable/index.js
@@ -43,7 +43,7 @@ const StrategyTradesTable = ({
 }
 
 StrategyTradesTable.propTypes = {
-  trades: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line
+  trades: PropTypes.arrayOf(PropTypes.object).isRequired,
   onTradeClick: PropTypes.func.isRequired,
   label: PropTypes.string,
   dark: PropTypes.bool,

--- a/src/components/TradesTablePanel/TradesTablePanel.js
+++ b/src/components/TradesTablePanel/TradesTablePanel.js
@@ -144,12 +144,12 @@ TradesTablePanel.propTypes = {
     }),
   }),
   canChangeMarket: PropTypes.bool,
-  allMarketTrades: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line
+  allMarketTrades: PropTypes.arrayOf(PropTypes.object),
   onRemove: PropTypes.func.isRequired,
   layoutI: PropTypes.string.isRequired,
   layoutID: PropTypes.string,
   updateState: PropTypes.func.isRequired,
-  markets: PropTypes.objectOf(PropTypes.object).isRequired, // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object).isRequired,
   activeMarket: PropTypes.shape({
     uiID: PropTypes.string,
   }).isRequired,

--- a/src/components/TradingStatePanel/TradingStatePanel.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.js
@@ -136,7 +136,7 @@ TradingStatePanel.propTypes = {
   getPositionsCount: PropTypes.func,
   getAtomicOrdersCount: PropTypes.func,
   getAlgoOrdersCount: PropTypes.func,
-  markets: PropTypes.objectOf(PropTypes.object).isRequired, // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object).isRequired,
   savedState: PropTypes.shape({
     currentMarket: PropTypes.shape({
       base: PropTypes.string,

--- a/src/modals/ActiveAlgoOrdersModal/ActiveAlgoOrdersModal.js
+++ b/src/modals/ActiveAlgoOrdersModal/ActiveAlgoOrdersModal.js
@@ -128,9 +128,7 @@ const ActiveAlgoOrdersModal = ({
 
 ActiveAlgoOrdersModal.propTypes = {
   handleActiveOrders: PropTypes.func.isRequired,
-  activeAlgoOrders: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.object,
-  ])),
+  activeAlgoOrders: PropTypes.arrayOf(PropTypes.object),
   isOpen: PropTypes.bool.isRequired,
 }
 

--- a/src/modals/ActiveAlgoOrdersModal/ActiveAlgoOrdersModal.table.js
+++ b/src/modals/ActiveAlgoOrdersModal/ActiveAlgoOrdersModal.table.js
@@ -40,9 +40,7 @@ AlgoOrdersTable.propTypes = {
   isOrderSelected: PropTypes.func,
   isAllOrdersSelected: PropTypes.func,
   onOrderSelect: PropTypes.func.isRequired,
-  orders: PropTypes.arrayOf(PropTypes.objectOf([
-    PropTypes.string, PropTypes.number, PropTypes.object,
-  ])),
+  orders: PropTypes.arrayOf(PropTypes.object),
   onAllOrdersSelect: PropTypes.func.isRequired,
 }
 

--- a/src/modals/EditOrderModal/EditOrderModal.js
+++ b/src/modals/EditOrderModal/EditOrderModal.js
@@ -245,7 +245,7 @@ EditOrderModal.propTypes = {
   gaEditAO: PropTypes.func.isRequired,
   cancelAlgoOrder: PropTypes.func.isRequired,
   submitAlgoOrder: PropTypes.func.isRequired,
-  markets: PropTypes.objectOf(PropTypes.object).isRequired, // eslint-disable-line
+  markets: PropTypes.objectOf(PropTypes.object).isRequired,
 }
 
 export default memo(EditOrderModal)

--- a/src/modals/Strategy/OpenExistingStrategyModal/OpenExistingStrategyModal.js
+++ b/src/modals/Strategy/OpenExistingStrategyModal/OpenExistingStrategyModal.js
@@ -77,7 +77,7 @@ const OpenExistingStrategyModal = ({
 OpenExistingStrategyModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onOpen: PropTypes.func.isRequired,
-  strategies: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line
+  strategies: PropTypes.arrayOf(PropTypes.object).isRequired,
   isOpen: PropTypes.bool,
 }
 


### PR DESCRIPTION
Seems PropTypes.objectOf and PropTypes.arrayOf only accepts single non-array argument, and so syntax like `PropTypes.arrayOf([PropTypes.number, PropTypes.string])` throws error
Ref: https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes

This reverts commit 852148e5061b2b1d95c074784024b2f3ab44c348.