### PR TITLE
(fix) only show 'update version' button for non-rc releases

### DIFF
--- a/src/redux/selectors/ui/get_remote_version.js
+++ b/src/redux/selectors/ui/get_remote_version.js
@@ -1,6 +1,12 @@
 import _get from 'lodash/get'
+import _includes from 'lodash/includes'
 import { REDUCER_PATHS } from '../../config'
 
 const path = REDUCER_PATHS.UI
 
-export default (state) => _get(state, `${path}.remoteVersion`, null)
+const RC_KEYWORD = '-rc'
+
+export default (state) => {
+  const version = _get(state, `${path}.remoteVersion`, null)
+  return _includes(version, RC_KEYWORD) ? '' : version
+}


### PR DESCRIPTION
[[HF-App] Do not show RC (internal releases) as "Update version" in StatusBar](https://app.asana.com/0/1201849173362898/1202257433823527/f)