### PR TITLE
(fix): Able to open strategies without strategyOptions

### DIFF
--- a/src/pages/Strategies/Strategies.container.js
+++ b/src/pages/Strategies/Strategies.container.js
@@ -6,12 +6,14 @@ import WSActions from '../../redux/actions/ws'
 
 import StrategiesPage from './Strategies'
 import { getAuthToken } from '../../redux/selectors/ws'
+import { getMarketsForExecution } from '../../redux/selectors/meta'
 
 const mapStateToProps = (state) => ({
   authToken: getAuthToken(state),
   firstLogin: getFirstLogin(state),
   isGuideActive: getGuideStatusForPage(state, STRATEGY_PAGE),
   strategyContent: state.ui.content,
+  markets: getMarketsForExecution(state),
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/pages/Strategies/Strategies.js
+++ b/src/pages/Strategies/Strategies.js
@@ -20,6 +20,7 @@ import {
 import Layout from '../../components/Layout'
 import useTourGuide from '../../hooks/useTourGuide'
 import SaveUnsavedChangesModal from '../../modals/Strategy/SaveUnsavedChangesModal'
+import { getDefaultStrategyOptions } from '../../components/StrategyEditor/StrategyEditor.helpers'
 
 import './style.css'
 
@@ -38,6 +39,7 @@ const StrategiesPage = ({
   strategyContent,
   authToken,
   onSave,
+  markets,
 }) => {
   const [strategy, setStrategy] = useState(strategyContent)
   const [indicators, setIndicators] = useState([])
@@ -178,6 +180,10 @@ const StrategiesPage = ({
       setNextStrategyToOpen(newStrategy)
       setIsUnsavedStrategyModalOpen(true)
       return
+    }
+    if (!newStrategy?.strategyOptions) {
+      // eslint-disable-next-line no-param-reassign
+      newStrategy.strategyOptions = getDefaultStrategyOptions(markets)
     }
     selectStrategyHandler(newStrategy, forcedLoad)
     setSectionErrors({})

--- a/src/pages/Strategies/Strategies.js
+++ b/src/pages/Strategies/Strategies.js
@@ -260,6 +260,7 @@ StrategiesPage.propTypes = {
   strategyContent: PropTypes.objectOf(Object),
   authToken: PropTypes.string.isRequired,
   onSave: PropTypes.func.isRequired,
+  markets: PropTypes.objectOf(PropTypes.object).isRequired, // eslint-disable-line
 }
 
 StrategiesPage.defaultProps = {

--- a/src/pages/Strategies/Strategies.js
+++ b/src/pages/Strategies/Strategies.js
@@ -1,6 +1,4 @@
-import React, {
-  lazy, Suspense, useState,
-} from 'react'
+import React, { lazy, Suspense, useState } from 'react'
 import Debug from 'debug'
 import PropTypes from 'prop-types'
 import randomColor from 'randomcolor'
@@ -9,6 +7,7 @@ import _values from 'lodash/values'
 import _map from 'lodash/map'
 // import _remove from 'lodash/remove'
 import _forEach from 'lodash/forEach'
+import _isEmpty from 'lodash/isEmpty'
 import Indicators from 'bfx-hf-indicators'
 import { nonce } from 'bfx-api-node-util'
 import HFS from 'bfx-hf-strategy'
@@ -176,22 +175,22 @@ const StrategiesPage = ({
 
   const onLoadStrategy = (newStrategy, forcedLoad = false) => {
     // const updated = { ...newStrategy, savedTs: Date.now() }
+    const strategyToLoad = { ...newStrategy }
     if (strategyDirty && !forcedLoad) {
-      setNextStrategyToOpen(newStrategy)
+      setNextStrategyToOpen(strategyToLoad)
       setIsUnsavedStrategyModalOpen(true)
       return
     }
-    if (!newStrategy?.strategyOptions) {
-      // eslint-disable-next-line no-param-reassign
-      newStrategy.strategyOptions = getDefaultStrategyOptions(markets)
+    if (_isEmpty(strategyToLoad?.strategyOptions)) {
+      strategyToLoad.strategyOptions = getDefaultStrategyOptions(markets)
     }
-    selectStrategyHandler(newStrategy, forcedLoad)
+    selectStrategyHandler(strategyToLoad, forcedLoad)
     setSectionErrors({})
     setNextStrategyToOpen(null)
     setStrategyDirty(false)
 
-    if (newStrategy.defineIndicators) {
-      onDefineIndicatorsChange(newStrategy.defineIndicators)
+    if (strategyToLoad.defineIndicators) {
+      onDefineIndicatorsChange(strategyToLoad.defineIndicators)
     }
   }
 


### PR DESCRIPTION
If user opens old strategy without `strategyOptions`, app crashes

Pending for @Blaumaus approve before merge