### PR TITLE
(fix) CSV exports for backtest trades table

### DIFF
--- a/src/components/BacktestTradesTable/BacktestTradesTable.helpers.js
+++ b/src/components/BacktestTradesTable/BacktestTradesTable.helpers.js
@@ -3,14 +3,15 @@ import { saveAs } from 'file-saver'
 import _map from 'lodash/map'
 import _split from 'lodash/split'
 import _replace from 'lodash/replace'
+import { getPairFromMarket } from '../../util/market'
 
-const getExportFilename = (activeMarket) => {
+const getExportFilename = (prefix) => {
   // turn something like 2022-02-22T12:55:03.800Z into 2022-02-22T12-55-03
   const date = _replace(_split(new Date().toISOString(), '.')[0], /:/g, '-')
-  return `${activeMarket}-${date}.zip`
+  return `${prefix}-${date}.zip`
 }
 
-const onTradeExportClick = (rawTrades, results, activeMarket, t) => {
+const onTradeExportClick = (rawTrades, results, activeMarket, t, getCurrencySymbol) => {
   const {
     nCandles,
     nTrades,
@@ -73,7 +74,7 @@ const onTradeExportClick = (rawTrades, results, activeMarket, t) => {
 
   csvExport.export(documents, (buffer) => {
     const blob = new Blob([buffer], { type: 'application/zip' })
-    const filename = getExportFilename(activeMarket)
+    const filename = getExportFilename(getPairFromMarket(activeMarket, getCurrencySymbol, '-'))
 
     saveAs(blob, filename)
   })

--- a/src/components/BacktestTradesTable/BacktestTradesTable.js
+++ b/src/components/BacktestTradesTable/BacktestTradesTable.js
@@ -1,5 +1,6 @@
 import React, { memo, useState } from 'react'
 import { Button, VirtualTable } from '@ufx-ui/core'
+import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import _isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
@@ -19,6 +20,8 @@ import { getActiveMarket } from '../../redux/selectors/ui'
 
 import './style.css'
 
+const { getCurrencySymbolMemo } = reduxSelectors
+
 const BacktestTradesTable = ({
   results,
   onTradeClick,
@@ -29,6 +32,7 @@ const BacktestTradesTable = ({
   const activeMarket = useSelector(getActiveMarket)
   const strategyTrades = results.strategy?.trades
   const { trades = strategyTrades } = results
+  const getCurrencySymbol = useSelector(getCurrencySymbolMemo)
 
   const onExpandClick = () => {
     const currentElementIndex = _findIndex(
@@ -68,7 +72,7 @@ const BacktestTradesTable = ({
         <>
           <Button
             className='panel-button'
-            onClick={() => onTradeExportClick(trades, results, activeMarket, t)}
+            onClick={() => onTradeExportClick(trades, results, activeMarket, t, getCurrencySymbol)}
           >
             <Icon name='file' />
             &nbsp;&nbsp;

--- a/src/components/StrategyTradesTable/StrategyTradesTable.helpers.js
+++ b/src/components/StrategyTradesTable/StrategyTradesTable.helpers.js
@@ -5,10 +5,10 @@ import _split from 'lodash/split'
 import _replace from 'lodash/replace'
 import { getPairFromMarket } from '../../util/market'
 
-const getExportFilename = (activeMarket) => {
+const getExportFilename = (prefix) => {
   // turn something like 2022-02-22T12:55:03.800Z into 2022-02-22T12-55-03
   const date = _replace(_split(new Date().toISOString(), '.')[0], /:/g, '-')
-  return `${activeMarket}-${date}.zip`
+  return `${prefix}-${date}.zip`
 }
 
 const onTradeExportClick = (rawTrades, results, activeMarket, t, getCurrencySymbol) => {


### PR DESCRIPTION
ASANA Ticket: [Strategy title of exported csv is [Object object]](https://app.asana.com/0/1201849173362898/1202418131029964/f)

This PR fixed the same issue as in ticket, but for backtest trades panel.

UI Demonstration:
![image](https://user-images.githubusercontent.com/35810911/173339385-5c1f6d14-b2fb-4d67-bd69-dfdede828df4.png)
