### PR TITLE
(fix) launching strategy on sandbox mode unnecessarily asks for API keys

### DIFF
--- a/src/redux/selectors/ws/get_current_mode_api_key_state.js
+++ b/src/redux/selectors/ws/get_current_mode_api_key_state.js
@@ -6,12 +6,12 @@ import { getIsPaperTrading } from '../ui'
 const path = REDUCER_PATHS.WS
 const EMPTY_OBJ = {}
 
-const apiKeyStates = (state) => _get(state, `${path}.auth.apiKeys`, EMPTY_OBJ)
+export const getAPIKeyStates = (state) => _get(state, `${path}.auth.apiKeys`, EMPTY_OBJ)
 
 const getCurrentModeAPIKeyState = createSelector(
   [
     getIsPaperTrading,
-    apiKeyStates,
+    getAPIKeyStates,
   ],
   (isPaperTradingMode, apiKeys) => (isPaperTradingMode ? apiKeys.paper : apiKeys.main),
 )

--- a/src/redux/selectors/ws/index.js
+++ b/src/redux/selectors/ws/index.js
@@ -33,7 +33,7 @@ import {
 
 import getPaperAPIKeyState from './get_paper_api_key_state'
 import getMainAPIKeyState from './get_main_api_key_state'
-import getCurrentModeAPIKeyState from './get_current_mode_api_key_state'
+import getCurrentModeAPIKeyState, { getAPIKeyStates } from './get_current_mode_api_key_state'
 import getIsMainModeApiKeyUpdating from './get_is_main_mode_api_key_updating'
 import getIsPaperModeApiKeyUpdating from './get_is_paper_mode_api_key_updating'
 
@@ -84,6 +84,7 @@ export {
 
   getPaperAPIKeyState,
   getMainAPIKeyState,
+  getAPIKeyStates,
   getCurrentModeAPIKeyState,
   getIsMainModeApiKeyUpdating,
   getIsPaperModeApiKeyUpdating,

--- a/src/util/market.js
+++ b/src/util/market.js
@@ -3,6 +3,7 @@ import _first from 'lodash/first'
 import _get from 'lodash/get'
 import _includes from 'lodash/includes'
 import _replace from 'lodash/replace'
+import { ALLOWED_PAPER_PAIRS, MAIN_MODE, PAPER_MODE } from '../redux/reducers/ui'
 
 export const getDefaultMarket = (markets) => _get(markets, [_first(_keys(markets))], 'uiID')
 
@@ -15,3 +16,5 @@ export const getCorrectIconNameOfPerpCcy = (perpCcy) => {
   }
   return perpCcy
 }
+
+export const getStrategyModeForSymbol = (symbol) => (_includes(ALLOWED_PAPER_PAIRS, symbol?.wsID) ? PAPER_MODE : MAIN_MODE)


### PR DESCRIPTION
[Launching strategy on live mode unnecessarily asks for API keys](https://app.asana.com/0/1201849173362898/1202404379214404/f)