### PR TITLE
fix crossed under

### DIFF
--- a/src/components/StrategyEditor/templates/macd_cross/onPriceUpdate.js
+++ b/src/components/StrategyEditor/templates/macd_cross/onPriceUpdate.js
@@ -33,15 +33,6 @@ const lookForTrade = async (state = {}, update = {}) => {
     })
   }
 
-  const crossedUnder = (
-    (current.macd <= current.signal) &&
-    (previous.macd >= previous.signal)
-  )
-
-  if (crossedUnder) {
-    return HFS.closePositionMarket(state, { price, mtsCreate: mts })
-  }
-
   return state
 }
 


### PR DESCRIPTION
Dealing with the `crossed under` state is done by the `whenLong` func, this code here will cause the same behavior as shorting.

This a patch of: https://github.com/bitfinexcom/bfx-hf-ui-core/pull/372