### PR TITLE
(fix) Execution options - save and launch mechanic is being inherited

### DIFF
--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -139,6 +139,11 @@ const StrategyEditor = (props) => {
     closeExecutionOptionsModal()
     closeCancelProcessModal()
     closeLaunchStrategyModal()
+
+    // setTimeout is needed to prevent flickering when 'Save & Launch' execution options modal is closing
+    setTimeout(() => {
+      setExecutionOptionsModalType(null)
+    }, 500)
   }, [closeCancelProcessModal, closeCreateNewStrategyFromModal, closeCreateNewStrategyModal, closeExecutionOptionsModal, closeLaunchStrategyModal, closeOpenExistingStrategyModal, closeRemoveModal, closeSaveStrategyAsModal])
 
   const onCreateNewStrategy = useCallback((label, content = {}) => {


### PR DESCRIPTION
ASANA Ticket: [Strategy params "save and launch" mechanic is being inherited](https://app.asana.com/0/1201849173362898/1202451864252620/f)

UI Demonstration:

https://user-images.githubusercontent.com/35810911/174087092-a946eb01-0658-48d6-bb48-ef9074fefe7b.mp4


