### PR TITLE
(fix) Dropdown overflow issues

### DIFF
--- a/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Live.js
+++ b/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Live.js
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next'
 
 import MarketSelect from '../MarketSelect'
 import Button from '../../ui/Button'
-import { makeShorterLongName } from '../../util/ui'
 import StrategyRunned from '../StrategyEditor/components/StrategyRunned'
 import StrategyStopped from '../StrategyEditor/components/StrategyStopped'
 import StrategyTypeSelect from './StrategyTypeSelect'
@@ -41,7 +40,7 @@ const StrategyOptionsPanelLive = ({
                 className='__react-tooltip __react_component_tooltip wide'
                 content={label}
               >
-                {makeShorterLongName(label, MAX_STRATEGY_LABEL_LENGTH)}
+                {label}
               </Tooltip>
             ) : (
               label

--- a/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Sandbox.js
+++ b/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Sandbox.js
@@ -11,7 +11,6 @@ import { Icon } from 'react-fa'
 import clsx from 'clsx'
 import MarketSelect from '../MarketSelect'
 import Button from '../../ui/Button'
-import { makeShorterLongName } from '../../util/ui'
 import StrategyTypeSelect from './StrategyTypeSelect'
 import { STRATEGY_OPTIONS_KEYS } from '../StrategyEditor/StrategyEditor.helpers'
 import StrategyOptionsButton from './StrategyOptionsButton'
@@ -58,7 +57,7 @@ const StrategyOptionsPanelSandbox = ({
                 className='__react-tooltip __react_component_tooltip wide'
                 content={label}
               >
-                {makeShorterLongName(label, MAX_STRATEGY_LABEL_LENGTH)}
+                {label}
               </Tooltip>
             ) : (
               label

--- a/src/components/StrategyOptionsPanel/style.scss
+++ b/src/components/StrategyOptionsPanel/style.scss
@@ -11,6 +11,10 @@
     }
   }
 
+  .hfui-orderform__input-label {
+    white-space: nowrap;
+  }
+
   &__left-container {
     display: flex;
     width: 80%;
@@ -63,6 +67,10 @@
     font-size: 20px;
     font-weight: 700;
     cursor: pointer;
+    max-width: 25ch;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
     &:hover {
       text-decoration: underline;
@@ -122,7 +130,6 @@
     cursor: pointer;
     text-transform: uppercase;
     height: 32px;
-    width: 110px;
 
     .hfui-exchangeinfobar__button {
       &:hover,


### PR DESCRIPTION
ASANA Ticket: [When strategy name is in 2 rows dropdown inputs overlap](https://app.asana.com/0/1201849173362898/1202456198328553/f)

UI Demonstration:

https://user-images.githubusercontent.com/35810911/174651912-08ec5abf-fb81-4c4b-9397-89ac969b473e.mp4


