### PR TITLE
(improvement) Fees metric should be red-coloured

### DIFF
--- a/src/components/Backtester/Results/Results.utils.js
+++ b/src/components/Backtester/Results/Results.utils.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import _toNumber from 'lodash/toNumber'
 import _isNaN from 'lodash/isNaN'
+import _isBoolean from 'lodash/isBoolean'
 import { isFiat, formatNumber } from '@ufx-ui/utils'
 import { Tooltip } from '@ufx-ui/core'
 import getQuotePrefix from '../../../util/quote_prefix'
@@ -20,14 +21,14 @@ const appendUnit = (value, unit, prefix) => {
 
 const getSmallestUnit = (isFiatValue) => (isFiatValue ? 0.01 : 0.00000001)
 
-export const resultNumber = (value, ccy) => {
+export const resultNumber = (value, ccy, isPositive) => {
   if (_isNaN(value)) {
     return '--'
   }
 
   const val = _toNumber(value)
   const isZero = val === 0
-  const isPositive = val > 0
+  const _isPositive = _isBoolean(isPositive) ? isPositive : val > 0
 
   let maxDecimals = FIAT_MAX_DECIMALS
   const isCcyFiat = isFiat(ccy)
@@ -47,7 +48,7 @@ export const resultNumber = (value, ccy) => {
     ? appendUnit(decimalNumberString, quotePrefix, isCcyFiat)
     : isZero
       ? appendUnit(0, quotePrefix, isCcyFiat)
-      : isPositive
+      : _isPositive
         ? appendUnit(
           `<${smallestUnit}`,
           quotePrefix,
@@ -55,7 +56,7 @@ export const resultNumber = (value, ccy) => {
         )
         : appendUnit(`>-${smallestUnit}`, quotePrefix, isCcyFiat)
 
-  const style = { color: isPositive ? 'green' : 'red' }
+  const style = { color: _isPositive ? 'green' : 'red' }
 
   return (
     <Tooltip

--- a/src/components/StrategyPerfomanceMetrics/StrategyPerfomanceMetrics.helpers.js
+++ b/src/components/StrategyPerfomanceMetrics/StrategyPerfomanceMetrics.helpers.js
@@ -54,7 +54,7 @@ const getMetrics = (results, t, quoteCcy, postProcessing = false) => {
       [t('strategyEditor.positions')]: nOpens,
       [t('strategyEditor.gains')]: nGains,
       [t('strategyEditor.losses')]: nLosses,
-      [t('strategyEditor.fees')]: resultNumber(fees, quoteCcy),
+      [t('strategyEditor.fees')]: resultNumber(fees, quoteCcy, false),
       [t('strategyEditor.volume')]: vol,
       [t('strategyEditor.largestGain')]: resultNumber(maxPL, quoteCcy),
       [t('strategyEditor.largestLoss')]: resultNumber(minPL, quoteCcy),


### PR DESCRIPTION
**ASANA Ticket:** [Fees metric should be red-coloured](https://app.asana.com/0/1201849173362898/1202472670271011/f)

**UI Demonstration:**
Before:
![Screenshot from 2022-06-20 20-24-56](https://user-images.githubusercontent.com/35810911/174652936-6da4547d-2fea-4bc8-8140-422dc991e4f8.png)

After:
![Screenshot from 2022-06-20 20-26-22](https://user-images.githubusercontent.com/35810911/174652967-57fb9442-2651-41f3-b820-7b722b923158.png)

