### PR TITLE
(fix) Executed strategies sorting issues

### DIFF
--- a/src/components/StrategiesListTable/StrategiesList.columns.js
+++ b/src/components/StrategiesListTable/StrategiesList.columns.js
@@ -88,7 +88,7 @@ const pastStrategiesColumns = (t, getMarketPair) => [
   },
   {
     label: t('table.pair'),
-    dataKey: 'pair',
+    dataKey: 'strategyOptions.symbol',
     style: STYLES.flexStart,
     headerStyle: STYLES.flexStart,
     width: 100,
@@ -124,7 +124,7 @@ const pastStrategiesColumns = (t, getMarketPair) => [
   // },
   {
     label: t('strategyEditor.profitFactor'),
-    dataKey: 'profitFactor',
+    dataKey: 'results.pf',
     style: STYLES.flexStart,
     headerStyle: STYLES.flexStart,
     width: 100,
@@ -142,7 +142,7 @@ const pastStrategiesColumns = (t, getMarketPair) => [
   // },
   {
     label: t('table.pl'),
-    dataKey: 'sharpeRatio',
+    dataKey: 'results.pl',
     style: STYLES.flexStart,
     headerStyle: STYLES.flexStart,
     width: 100,


### PR DESCRIPTION
### Asana task:
[Executed strategies: Pair, Profit Factor and P/L sorting does not working](https://app.asana.com/0/1201849173362898/1202494461064381/f)

https://user-images.githubusercontent.com/35810911/175533065-b5dcd901-be9b-4be5-8252-9a2f3176d106.mp4


