### PR TITLE
(fix) ws disconnection for ufx ws endpoints

### DIFF
--- a/src/redux/sagas/ws/worker_ping_reboot_app.js
+++ b/src/redux/sagas/ws/worker_ping_reboot_app.js
@@ -1,7 +1,4 @@
-import { put, delay, select } from 'redux-saga/effects'
-import { reduxSelectors } from '@ufx-ui/bfx-containers'
-
-import UIActions from '../../actions/ui'
+import { put, delay } from 'redux-saga/effects'
 import WSActions from '../../actions/ws'
 import { isElectronApp } from '../../config'
 
@@ -10,11 +7,8 @@ const PING_AND_CHECK_CONNECTION_INTERVAL_MS = 30 * 1000 // 30 seconds
 export default function* () {
   while (true) {
     yield delay(PING_AND_CHECK_CONNECTION_INTERVAL_MS)
-    const isWSconnected = yield select(reduxSelectors.getWSConnected)
 
-    if (!isWSconnected) {
-      yield put(UIActions.changeBadInternetConnectionState(true))
-    } else if (!isElectronApp) { // send ping to bfx-hf-hosted every 30 ms
+    if (!isElectronApp) { // send ping to bfx-hf-hosted every 30 ms
       yield put(WSActions.send({ event: 'ping' }))
     }
   }


### PR DESCRIPTION
### Asana task:
[On login, app always crashes one time, even though no errors are shown](https://app.asana.com/0/1201848935859401/1202352426248857/f)

### Description:
Right now we show relaunch app modal, when there is disconnection for ufx websockets which shows data for book and trades component, but ufx ws endpoints auto establishes connection when internet is back and also trades/book data are not that critical that user can't take further action, so not need to do app reload in this case 

### Related Pull Requests:
...

### Backend Dependencies:
...

### Other Dependencies:
...

