### PR TITLE
(fix) chart interval resetting to 30m once new open trades/position is updated

### DIFF
--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -2,6 +2,7 @@ import React, { memo, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { reduxSelectors } from '@ufx-ui/bfx-containers'
 import PropTypes from 'prop-types'
+import _isUndefined from 'lodash/isUndefined'
 
 import { useTranslation } from 'react-i18next'
 import { LANGUAGES_CHART_TABLE } from '../../locales/i18n'
@@ -25,6 +26,7 @@ const Chart = ({
   hideResolutions,
   chartRange,
 }) => {
+  const isSetInterval = !_isUndefined(interval)
   const {
     wsID, base, quote, isPerp, uiID: _uiID,
   } = market
@@ -35,7 +37,7 @@ const Chart = ({
 
   const uiID = isPerp ? _uiID : getPairFromMarket(market, getCurrencySymbol)
   const iframeID = `hfui-chart-${layoutI}`
-  const sendMarketToChartIframe = useChartIframe(iframeID, wsID, indicators, trades, interval, chartRange)
+  const sendMarketToChartIframe = useChartIframe(iframeID, wsID, indicators, trades, interval, isSetInterval, chartRange)
 
   const queryString = new URLSearchParams({
     env,
@@ -82,7 +84,7 @@ Chart.defaultProps = {
   },
   indicators: [],
   trades: [],
-  interval: '30',
+  interval: undefined,
   hideResolutions: false,
   chartRange: null,
 }

--- a/src/components/Chart/useChartIframe.js
+++ b/src/components/Chart/useChartIframe.js
@@ -26,7 +26,7 @@ import {
   GET_RANGE_EVENT,
 } from './events'
 
-const useChartIframe = (iframeID, wsID, customIndicators, trades, interval, range) => {
+const useChartIframe = (iframeID, wsID, customIndicators, trades, interval, isSetInterval, range) => {
   const [isIframeReady, setIsIframeReady] = useState(false)
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -52,13 +52,15 @@ const useChartIframe = (iframeID, wsID, customIndicators, trades, interval, rang
       sendMessageToIframe(iframeChart, GET_ORDERS_EVENT, orders)
       sendMessageToIframe(iframeChart, GET_POSITION_EVENT, position || {})
       sendMessageToIframe(iframeChart, GET_TRADES_EVENT, trades || [])
-      sendMessageToIframe(iframeChart, GET_INTERVAL_EVENT, interval || '')
+      if (isSetInterval) {
+        sendMessageToIframe(iframeChart, GET_INTERVAL_EVENT, interval || '')
+      }
       sendMessageToIframe(iframeChart, GET_RANGE_EVENT, range || {})
       if (!_isEmpty(customIndicators)) {
         sendMessageToIframe(iframeChart, GET_INDICATORS_EVENT, customIndicators || [])
       }
     }
-  }, [orders, iframeID, isIframeReady, position, customIndicators, trades, interval, range])
+  }, [orders, iframeID, isIframeReady, position, customIndicators, trades, interval, range, isSetInterval])
 
   const sendMarketToChartIframe = useCallback((market) => {
     const marketOrders = getChartOrders(market?.wsID, t)


### PR DESCRIPTION
### Asana task:
[Candle time on chart defaults to 30min](https://app.asana.com/0/1201849173362898/1202530511257891/f)

### Description:
set undefined interval when updating interval from parent i.e. HF app is not required

### Related Pull Requests:
https://github.com/bitfinexcom/bfx-hf-tradingview/pull/48

### Backend Dependencies:
...

### Other Dependencies:
...

