### PR TITLE
(fix) Reset loading state on cancel execution/backtest if `gid` is not exist

### DIFF
--- a/src/components/StrategyEditor/StrategyEditor.container.js
+++ b/src/components/StrategyEditor/StrategyEditor.container.js
@@ -141,6 +141,7 @@ const mapDispatchToProps = (dispatch) => ({
     if (isPaperTrading) {
       // stopping backtesting
       if (!backtestGid) {
+        dispatch(WSActions.purgeBacktestData())
         return
       }
       dispatch(
@@ -151,6 +152,7 @@ const mapDispatchToProps = (dispatch) => ({
       )
     } else {
       if (!liveExecGid) {
+        dispatch(WSActions.resetExecutionData())
         return
       }
       // stopping live execution

--- a/src/redux/reducers/ws/execution.js
+++ b/src/redux/reducers/ws/execution.js
@@ -151,17 +151,14 @@ function reducer(state = getInitialState(), action = {}) {
       }
     }
 
-    case types.DISCONNECTED: {
+    case types.DISCONNECTED:
+    case types.RESET_DATA_EXECUTION: {
       return {
         ...state,
         loading: false,
         loadingGid: null,
         activeStrategies: {},
       }
-    }
-
-    case types.RESET_DATA_EXECUTION: {
-      return getInitialState()
     }
 
     default: {


### PR DESCRIPTION
### Asana task:
https://app.asana.com/0/1201849173362898/1202463367205711
### Description:
...

### Related Pull Requests:
...

### Backend Dependencies:
...

### Other Dependencies:
...

