### PR TITLE
hide indicators for strategy chart

### DIFF
--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -24,6 +24,7 @@ const Chart = ({
   trades,
   interval,
   hideResolutions,
+  hideIndicators,
   chartRange,
 }) => {
   const isSetInterval = !_isUndefined(interval)
@@ -45,6 +46,7 @@ const Chart = ({
     locale: LANGUAGES_CHART_TABLE[i18nMappedKey] || LANGUAGES_CHART_TABLE.en,
     iframeID,
     hideResolutions,
+    hideIndicators,
   }).toString()
 
   useEffect(() => {
@@ -72,6 +74,7 @@ Chart.propTypes = {
   trades: PropTypes.arrayOf(PropTypes.shape(TRADE_SHAPE)),
   interval: PropTypes.string,
   hideResolutions: PropTypes.bool,
+  hideIndicators: PropTypes.bool,
   chartRange: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 }
 
@@ -86,6 +89,7 @@ Chart.defaultProps = {
   trades: [],
   interval: undefined,
   hideResolutions: false,
+  hideIndicators: false,
   chartRange: null,
 }
 

--- a/src/components/StrategyLiveChart/StrategyLiveChart.js
+++ b/src/components/StrategyLiveChart/StrategyLiveChart.js
@@ -101,6 +101,7 @@ const StrategyLiveChart = ({
           interval={interval}
           trades={trades}
           hideResolutions
+          hideIndicators
           chartRange={chartRange}
           key={executionId}
         />


### PR DESCRIPTION
### Asana task:
[Remove TV indicators shortcut from strategy charts](https://app.asana.com/0/1201849173362898/1202611291143406/f)

### Description:
...

### Related Pull Requests:
https://github.com/bitfinexcom/bfx-hf-tradingview/pull/54

### Backend Dependencies:
...

### Other Dependencies:
...

