### PR TITLE
(improvement) Strategy options panel layout

### DIFF
--- a/src/components/StrategyEditor/tabs/StrategyTab/StrategyLiveTab.js
+++ b/src/components/StrategyEditor/tabs/StrategyTab/StrategyLiveTab.js
@@ -35,7 +35,6 @@ const StrategyLiveTab = (props) => {
     indicators,
     openExecutionOptionsModal,
     stopExecution,
-    saveStrategyOptions,
     onCancelProcess,
   } = props
   const [layoutConfig, setLayoutConfig] = useState()
@@ -73,7 +72,6 @@ const StrategyLiveTab = (props) => {
               markets={markets}
               openExecutionOptionsModal={openExecutionOptionsModal}
               stopExecution={stopExecution}
-              saveStrategyOptions={saveStrategyOptions}
               setFullScreenChart={setFullScreenChart}
               isExecuting={executing}
               hasResults={hasResults}
@@ -119,7 +117,6 @@ const StrategyLiveTab = (props) => {
       markets,
       openExecutionOptionsModal,
       stopExecution,
-      saveStrategyOptions,
       setFullScreenChart,
       executing,
       hasResults,
@@ -151,7 +148,6 @@ StrategyLiveTab.propTypes = {
   onCancelProcess: PropTypes.func.isRequired,
   strategy: PropTypes.shape(STRATEGY_SHAPE).isRequired,
   markets: PropTypes.arrayOf(PropTypes.shape(MARKET_SHAPE)).isRequired,
-  saveStrategyOptions: PropTypes.func.isRequired,
   openExecutionOptionsModal: PropTypes.func.isRequired,
   stopExecution: PropTypes.func.isRequired,
   indicators: INDICATORS_ARRAY_SHAPE,

--- a/src/components/StrategyOptionsPanel/StrategyMarketSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyMarketSelect.js
@@ -1,0 +1,93 @@
+import React from 'react'
+import _isEmpty from 'lodash/isEmpty'
+import _includes from 'lodash/includes'
+import _find from 'lodash/find'
+import PropTypes from 'prop-types'
+import clsx from 'clsx'
+import { Tooltip } from '@ufx-ui/core'
+import { useTranslation } from 'react-i18next'
+import MarketSelect from '../MarketSelect'
+import { STRATEGY_OPTIONS_KEYS } from '../StrategyEditor/StrategyEditor.helpers'
+import {
+  MARKET_SHAPE,
+  STRATEGY_SHAPE,
+} from '../../constants/prop-types-shapes'
+
+const StrategyMarketSelect = ({
+  symbol,
+  saveStrategyOptions,
+  markets,
+  isDisabled,
+}) => {
+  const onMarketSelectChange = (selection) => {
+    if (isDisabled) {
+      return
+    }
+    const sel = _find(markets, (m) => m.wsID === selection.wsID)
+    const options = {
+      [STRATEGY_OPTIONS_KEYS.SYMBOL]: sel,
+    }
+
+    if (!_includes(sel?.contexts, 'm')) {
+      options[STRATEGY_OPTIONS_KEYS.MARGIN] = false
+    }
+    saveStrategyOptions(options)
+  }
+
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <div className='hfui-strategy-options__input hfui-strategy-options__input--unlimited item'>
+        <MarketSelect
+          value={symbol}
+          onChange={onMarketSelectChange}
+          markets={markets}
+          placeholder={t('strategyEditor.selectMarketPlaceholder')}
+          renderWithFavorites
+          disabled={isDisabled}
+        />
+        {isDisabled ? (
+          <p className='hfui-orderform__input-label'>
+            {t('strategyEditor.selectMarketDescriptionDisabled')}
+          </p>
+        ) : (
+          <p
+            className={clsx('hfui-orderform__input-label', {
+              error: _isEmpty(symbol),
+            })}
+          >
+            <span>
+              <b>{t('ui.required')}</b>
+              .&nbsp;
+              {t('strategyEditor.selectMarketDescription')}
+            </span>
+          </p>
+        )}
+      </div>
+      <Tooltip
+        className='__react-tooltip __react-tooltip-break-line'
+        content={t('strategyEditor.capitalAllocationHelp')}
+      >
+        <i className='fa fa-info-circle __react_component_tooltip title-tooltip' />
+      </Tooltip>
+    </>
+  )
+}
+
+StrategyMarketSelect.propTypes = {
+  markets: PropTypes.arrayOf(PropTypes.shape(MARKET_SHAPE)).isRequired,
+  symbol: PropTypes.shape(
+    STRATEGY_SHAPE.strategyOptions[STRATEGY_OPTIONS_KEYS.SYMBOL],
+  ),
+  saveStrategyOptions: PropTypes.func,
+  isDisabled: PropTypes.bool,
+}
+
+StrategyMarketSelect.defaultProps = {
+  symbol: null,
+  isDisabled: false,
+  saveStrategyOptions: () => {},
+}
+
+export default StrategyMarketSelect

--- a/src/components/StrategyOptionsPanel/StrategyMarketSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyMarketSelect.js
@@ -48,14 +48,17 @@ const StrategyMarketSelect = ({
           disabled={isDisabled}
         />
         {isDisabled ? (
-          <p className='hfui-orderform__input-label'>
+          <p className='hfui-orderform__input-label hfui-strategy-options__description'>
             {t('strategyEditor.selectMarketDescriptionDisabled')}
           </p>
         ) : (
           <p
-            className={clsx('hfui-orderform__input-label', {
-              error: _isEmpty(symbol),
-            })}
+            className={clsx(
+              'hfui-orderform__input-label hfui-strategy-options__description',
+              {
+                error: _isEmpty(symbol),
+              },
+            )}
           >
             <b>{t('ui.required')}</b>
           </p>

--- a/src/components/StrategyOptionsPanel/StrategyMarketSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyMarketSelect.js
@@ -37,8 +37,8 @@ const StrategyMarketSelect = ({
   const { t } = useTranslation()
 
   return (
-    <>
-      <div className='hfui-strategy-options__input hfui-strategy-options__input--unlimited item'>
+    <div className='hfui-strategy-options__dropdown-wrapper item'>
+      <div className='hfui-strategy-options__input'>
         <MarketSelect
           value={symbol}
           onChange={onMarketSelectChange}
@@ -57,21 +57,23 @@ const StrategyMarketSelect = ({
               error: _isEmpty(symbol),
             })}
           >
-            <span>
-              <b>{t('ui.required')}</b>
-              .&nbsp;
-              {t('strategyEditor.selectMarketDescription')}
-            </span>
+            <b>{t('ui.required')}</b>
           </p>
         )}
       </div>
       <Tooltip
         className='__react-tooltip __react-tooltip-break-line'
-        content={t('strategyEditor.capitalAllocationHelp')}
+        content={(
+          <span>
+            <b>{t('ui.required')}</b>
+            .&nbsp;
+            {t('strategyEditor.selectMarketDescription')}
+          </span>
+        )}
       >
-        <i className='fa fa-info-circle __react_component_tooltip title-tooltip' />
+        <i className='fa fa-info-circle __react_component_tooltip' />
       </Tooltip>
-    </>
+    </div>
   )
 }
 

--- a/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Live.js
+++ b/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Live.js
@@ -5,7 +5,6 @@ import { Tooltip } from '@ufx-ui/core'
 import { useTranslation } from 'react-i18next'
 
 import { useSelector } from 'react-redux'
-import MarketSelect from '../MarketSelect'
 import Button from '../../ui/Button'
 import StrategyRunned from '../StrategyEditor/components/StrategyRunned'
 import StrategyStopped from '../StrategyEditor/components/StrategyStopped'
@@ -14,6 +13,7 @@ import StrategyTypeSelect from './StrategyTypeSelect'
 import StrategyOptionsButton from './StrategyOptionsButton'
 import { STRATEGY_SHAPE } from '../../constants/prop-types-shapes'
 import { getExecutionConnectionState } from '../../redux/selectors/ws'
+import StrategyMarketSelect from './StrategyMarketSelect'
 
 import './style.css'
 
@@ -27,7 +27,6 @@ const StrategyOptionsPanelLive = ({
   openExecutionOptionsModal,
   setFullScreenChart,
   stopExecution,
-  saveStrategyOptions,
 }) => {
   const { label, strategyOptions: { symbol, strategyType } = {} } = strategy || {}
   const { t } = useTranslation()
@@ -67,20 +66,12 @@ const StrategyOptionsPanelLive = ({
         <div className='hfui-strategy-options__option item'>
           {getIndicator()}
         </div>
-        <div className='hfui-strategy-options__input item'>
-          <MarketSelect
-            value={symbol}
-            markets={markets}
-            onChange={() => {}}
-            disabled
-            renderWithFavorites
-          />
-          <p className='hfui-orderform__input-label'>
-            {t('strategyEditor.selectMarketDescriptionDisabled')}
-          </p>
-        </div>
+        <StrategyMarketSelect
+          markets={markets}
+          symbol={symbol}
+          isDisabled
+        />
         <StrategyTypeSelect
-          saveStrategyOptions={saveStrategyOptions}
           strategyType={strategyType}
           isExecuting={isExecuting}
           isDisabled
@@ -114,7 +105,6 @@ StrategyOptionsPanelLive.propTypes = {
   strategy: PropTypes.shape(STRATEGY_SHAPE).isRequired,
   isExecuting: PropTypes.bool.isRequired,
   hasResults: PropTypes.bool.isRequired,
-  saveStrategyOptions: PropTypes.func.isRequired,
   openExecutionOptionsModal: PropTypes.func.isRequired,
   setFullScreenChart: PropTypes.func.isRequired,
   stopExecution: PropTypes.func.isRequired,

--- a/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Sandbox.js
+++ b/src/components/StrategyOptionsPanel/StrategyOptionsPanel.Sandbox.js
@@ -1,20 +1,16 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
-import _find from 'lodash/find'
 import _size from 'lodash/size'
-import _isEmpty from 'lodash/isEmpty'
 import { Tooltip } from '@ufx-ui/core'
-import _includes from 'lodash/includes'
 import { useTranslation } from 'react-i18next'
 
 import { Icon } from 'react-fa'
 import clsx from 'clsx'
-import MarketSelect from '../MarketSelect'
 import Button from '../../ui/Button'
 import StrategyTypeSelect from './StrategyTypeSelect'
-import { STRATEGY_OPTIONS_KEYS } from '../StrategyEditor/StrategyEditor.helpers'
 import StrategyOptionsButton from './StrategyOptionsButton'
-import { STRATEGY_SHAPE } from '../../constants/prop-types-shapes'
+import { MARKET_SHAPE, STRATEGY_SHAPE } from '../../constants/prop-types-shapes'
+import StrategyMarketSelect from './StrategyMarketSelect'
 
 import './style.css'
 
@@ -36,18 +32,6 @@ const StrategyOptionsPanelSandbox = ({
     strategyOptions: { symbol, strategyType } = {},
   } = strategy || {}
   const { t } = useTranslation()
-
-  const onMarketSelectChange = (selection) => {
-    const sel = _find(markets, (m) => m.wsID === selection.wsID)
-    const options = {
-      [STRATEGY_OPTIONS_KEYS.SYMBOL]: sel,
-    }
-
-    if (!_includes(sel?.contexts, 'm')) {
-      options[STRATEGY_OPTIONS_KEYS.MARGIN] = false
-    }
-    saveStrategyOptions(options)
-  }
 
   const onStrategyNameClick = () => {
     if (executionId) {
@@ -78,26 +62,11 @@ const StrategyOptionsPanelSandbox = ({
             )}
           </>
         </p>
-        <div className='hfui-strategy-options__input hfui-strategy-options__input--unlimited item'>
-          <MarketSelect
-            value={symbol}
-            onChange={onMarketSelectChange}
-            markets={markets}
-            placeholder={t('strategyEditor.selectMarketPlaceholder')}
-            renderWithFavorites
-          />
-          <p
-            className={clsx('hfui-orderform__input-label', {
-              error: _isEmpty(symbol),
-            })}
-          >
-            <span>
-              <b>{t('ui.required')}</b>
-              .&nbsp;
-              {t('strategyEditor.selectMarketDescription')}
-            </span>
-          </p>
-        </div>
+        <StrategyMarketSelect
+          saveStrategyOptions={saveStrategyOptions}
+          markets={markets}
+          symbol={symbol}
+        />
         <StrategyTypeSelect
           saveStrategyOptions={saveStrategyOptions}
           strategyType={strategyType}
@@ -133,7 +102,7 @@ const StrategyOptionsPanelSandbox = ({
 }
 
 StrategyOptionsPanelSandbox.propTypes = {
-  markets: PropTypes.arrayOf(Object).isRequired,
+  markets: PropTypes.arrayOf(PropTypes.shape(MARKET_SHAPE)).isRequired,
   saveStrategyOptions: PropTypes.func.isRequired,
   strategy: PropTypes.shape(STRATEGY_SHAPE).isRequired,
   openExecutionOptionsModal: PropTypes.func.isRequired,

--- a/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
@@ -168,7 +168,7 @@ StrategyTypeSelect.propTypes = {
     i18nKey: PropTypes.string,
     customValue: PropTypes.string,
   }),
-  saveStrategyOptions: PropTypes.func.isRequired,
+  saveStrategyOptions: PropTypes.func,
   isExecuting: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool,
 }
@@ -176,6 +176,7 @@ StrategyTypeSelect.propTypes = {
 StrategyTypeSelect.defaultProps = {
   strategyType: null,
   isDisabled: false,
+  saveStrategyOptions: () => {},
 }
 
 export default memo(StrategyTypeSelect)

--- a/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
@@ -143,7 +143,7 @@ const StrategyTypeSelect = ({
           }
           />
           {(isExecuting || isDisabled) && (
-          <p className='hfui-orderform__input-label'>
+          <p className='hfui-orderform__input-label hfui-strategy-options__description'>
             {t('strategyEditor.strategyTypeDescriptionDisabled')}
           </p>
           )}

--- a/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
@@ -5,7 +5,7 @@ import _map from 'lodash/map'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import { Icon } from 'react-fa'
-import { Button as UfxButton } from '@ufx-ui/core'
+import { Button as UfxButton, Tooltip } from '@ufx-ui/core'
 import Dropdown from '../../ui/Dropdown'
 import Input from '../../ui/Input'
 import Button from '../../ui/Button'
@@ -111,8 +111,8 @@ const StrategyTypeSelect = ({
   }, [strategyType])
 
   return (
-    <div className='hfui-strategy-options__type-selection item'>
-      <div className='hfui-strategy-options__input hfui-strategy-options__input--unlimited'>
+    <div className='hfui-strategy-options__dropdown-wrapper item'>
+      <div className='hfui-strategy-options__input'>
         <Dropdown
           value={strategyTypeDropdownValue}
           options={strategyTypesOptionsMemo}
@@ -124,11 +124,11 @@ const StrategyTypeSelect = ({
               : t('strategyEditor.strategyTypePlaceholder')
           }
         />
-        <p className='hfui-orderform__input-label'>
-          {isExecuting || isDisabled
-            ? t('strategyEditor.strategyTypeDescriptionDisabled')
-            : t('strategyEditor.strategyTypeDescription')}
-        </p>
+        {(isExecuting || isDisabled) && (
+          <p className='hfui-orderform__input-label'>
+            {t('strategyEditor.strategyTypeDescriptionDisabled')}
+          </p>
+        )}
       </div>
 
       {showCustomStrategyTypeInput && (
@@ -159,6 +159,12 @@ const StrategyTypeSelect = ({
           <Icon name='times' className='search-icon' />
         </UfxButton>
       )}
+      <Tooltip
+        className='__react-tooltip __react-tooltip-break-line'
+        content={t('strategyEditor.strategyTypeDescription')}
+      >
+        <i className='fa fa-info-circle __react_component_tooltip' />
+      </Tooltip>
     </div>
   )
 }

--- a/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
+++ b/src/components/StrategyOptionsPanel/StrategyTypeSelect.js
@@ -112,26 +112,7 @@ const StrategyTypeSelect = ({
 
   return (
     <div className='hfui-strategy-options__dropdown-wrapper item'>
-      <div className='hfui-strategy-options__input'>
-        <Dropdown
-          value={strategyTypeDropdownValue}
-          options={strategyTypesOptionsMemo}
-          onChange={onSelectStrategyType}
-          disabled={isDisabled || isExecuting || showCustomStrategyTypeInput}
-          placeholder={
-            isExecuting || isDisabled
-              ? t('ui.notSelected')
-              : t('strategyEditor.strategyTypePlaceholder')
-          }
-        />
-        {(isExecuting || isDisabled) && (
-          <p className='hfui-orderform__input-label'>
-            {t('strategyEditor.strategyTypeDescriptionDisabled')}
-          </p>
-        )}
-      </div>
-
-      {showCustomStrategyTypeInput && (
+      {showCustomStrategyTypeInput ? (
         <form
           className='hfui-strategy-options__strategy-type-input'
           onSubmit={saveCustomStrategyType}
@@ -148,6 +129,25 @@ const StrategyTypeSelect = ({
             className='hfui-strategy-options__ok-btn'
           />
         </form>
+      ) : (
+        <div className='hfui-strategy-options__input'>
+          <Dropdown
+            value={strategyTypeDropdownValue}
+            options={strategyTypesOptionsMemo}
+            onChange={onSelectStrategyType}
+            disabled={isDisabled || isExecuting}
+            placeholder={
+            isExecuting || isDisabled
+              ? t('ui.notSelected')
+              : t('strategyEditor.strategyTypePlaceholder')
+          }
+          />
+          {(isExecuting || isDisabled) && (
+          <p className='hfui-orderform__input-label'>
+            {t('strategyEditor.strategyTypeDescriptionDisabled')}
+          </p>
+          )}
+        </div>
       )}
 
       {strategyTypeDropdownValue && !isExecuting && !isDisabled && (

--- a/src/components/StrategyOptionsPanel/style.scss
+++ b/src/components/StrategyOptionsPanel/style.scss
@@ -95,6 +95,10 @@
     margin-bottom: 0;
   }
 
+  &__description{
+    padding-left: 11px;
+  }
+
   &__amount-input {
     padding: 8 16px;
   }

--- a/src/components/StrategyOptionsPanel/style.scss
+++ b/src/components/StrategyOptionsPanel/style.scss
@@ -78,6 +78,7 @@
     font-size: 20px;
     font-weight: 700;
     max-width: 25ch;
+    min-width: 12ch;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -91,33 +92,29 @@
   }
 
   &__input {
-    display: flex;
-    flex-direction: column;
-    max-width: 250px;
     margin-bottom: 0;
-
-    &--unlimited {
-      max-width: none;
-    }
   }
 
   &__amount-input {
-    @extend .hfui-strategy-options__input;
     padding: 8 16px;
   }
 
   &__strategy-type-input {
-    @extend .hfui-strategy-options__input;
+    display: flex;
     flex-direction: row;
   }
 
-  &__type-selection {
+  &__dropdown-wrapper {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
 
-    .hfui-strategy-options__input:not(:last-child) {
+    & > *:not(:last-child) {
       margin-right: 10px;
+    }
+
+    .__react_component_tooltip {
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
### Asana task:
https://app.asana.com/0/1201849173362898/1202734707618146
https://app.asana.com/0/1201849173362898/1202734707618137

### Description:
- replaced dropdown bottom description, which stretched dropdown component to tooltip
- set min width for strategy name
- render only strategy type description or custom type input for saving place

![Снимок экрана от 2022-08-09 16-37-56](https://user-images.githubusercontent.com/81973123/183664174-6fdfa61b-2551-41ed-9b40-67a662897437.png)
![Снимок экрана от 2022-08-09 16-38-07](https://user-images.githubusercontent.com/81973123/183664179-4eb4bba8-f4fa-45f8-beb3-6b85dac270b2.png)
![Снимок экрана от 2022-08-09 16-38-13](https://user-images.githubusercontent.com/81973123/183664185-34171609-ab9c-45d2-b0c5-8b61c90bc9aa.png)


### Related Pull Requests:
...

### Backend Dependencies:
...

### Other Dependencies:
...

