### PR TITLE
(fix) Improved getPairMarket selector

### DIFF
--- a/src/components/Navbar/Navbar.CloseSessionButton.js
+++ b/src/components/Navbar/Navbar.CloseSessionButton.js
@@ -42,7 +42,9 @@ const CloseSessionButton = () => {
       dispatch(changeUIModalState(UI_MODAL_KEYS.CLOSE_SESSION_MODAL, true))
       return
     }
-    ipcHelpers.sendAppClosedEvent()
+    if (ipcHelpers) {
+      ipcHelpers.sendAppClosedEvent()
+    }
   }
 
   const buttonHandler = () => (isElectronApp ? openCloseSessionModal() : logout())

--- a/src/components/StrategiesListTable/StrategiesListTable.js
+++ b/src/components/StrategiesListTable/StrategiesListTable.js
@@ -16,7 +16,7 @@ import {
   getSortedByTimeStrategies,
 } from '../../redux/selectors/ws'
 import {
-  getExecutionMarketPair,
+  getMarketPair,
   getMarketsForExecution,
 } from '../../redux/selectors/meta'
 import PastStrategiesList from './PastStrategiesList'
@@ -33,7 +33,7 @@ const StrategiesListTable = ({
   renameStrategy,
 }) => {
   const { t } = useTranslation()
-  const _getMarketPair = useSelector(getExecutionMarketPair)
+  const _getMarketPair = useSelector(getMarketPair)
   const activeStrategies = useSelector(getSortedByTimeActiveStrategies())
   const pastStrategies = useSelector(sortedByTimePastStrategies)
   const savedStrategies = useSelector(getSortedByTimeStrategies)

--- a/src/modals/CloseSessionModal/SessionList.js
+++ b/src/modals/CloseSessionModal/SessionList.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { getAlgoOrders, getSortedByTimeActiveStrategies, getSortedByTimeStrategies } from '../../redux/selectors/ws'
-import { getExecutionMarketPair, getMarketPair, getMarketsForExecution } from '../../redux/selectors/meta'
+import { getMarketPair, getMarketsForExecution } from '../../redux/selectors/meta'
 import { changeMode, setCurrentStrategy } from '../../redux/actions/ui'
 import routes from '../../constants/routes'
 import { showActiveOrdersModal } from '../../redux/actions/ao'
@@ -15,8 +15,7 @@ import { MAIN_MODE } from '../../redux/reducers/ui'
 
 const SessionList = ({ onModalClose }) => {
   const activeStrategies = useSelector(getSortedByTimeActiveStrategies())
-  const getMarketPairForStartegy = useSelector(getExecutionMarketPair)
-  const getMarketPairForOrder = useSelector(getMarketPair)
+  const _getMarketPair = useSelector(getMarketPair)
   const isPaperTrading = useSelector(getIsPaperTrading)
   const algoOrders = useSelector(getAlgoOrders)
   const savedStrategies = useSelector(getSortedByTimeStrategies)
@@ -69,7 +68,7 @@ const SessionList = ({ onModalClose }) => {
             &nbsp;
           <span className='secondary-label'>
             (
-            {getMarketPairForStartegy(strategy?.symbol)}
+            {_getMarketPair(strategy?.symbol)}
             ,&nbsp;
             {t('closeSessionModal.startedOn', {
               time: new Date(strategy.startedOn).toLocaleString(),
@@ -85,7 +84,7 @@ const SessionList = ({ onModalClose }) => {
           </span>
             &nbsp;
           <span className='secondary-label'>
-            {getMarketPairForOrder(order?.args?.symbol)}
+            {_getMarketPair(order?.args?.symbol)}
           </span>
         </li>
       ))}

--- a/src/redux/selectors/meta/get_markets.js
+++ b/src/redux/selectors/meta/get_markets.js
@@ -10,9 +10,8 @@ import {
   reduxSelectors,
   VOLUME_UNIT,
 } from '@ufx-ui/bfx-containers'
-import _isEmpty from 'lodash/isEmpty'
 
-import { getPairFromMarket } from '../../../util/market'
+import { getIsPaperPair, getPairFromMarket } from '../../../util/market'
 import { REDUCER_PATHS } from '../../config'
 import { getIsPaperTrading } from '../ui'
 import { MARKET_TYPES_KEYS } from '../../constants/market'
@@ -101,19 +100,16 @@ export const getMarketsSortedByVolumeForExecution = createSelector(
 )
 
 export const getMarketPair = createSelector(
-  [getMarkets, getCurrencySymbolMemo],
+  [getMarketsObject, getCurrencySymbolMemo],
   (markets, getCurrencySymbol) => memoizeOne((symbol) => {
-    const currentMarket = markets?.[symbol]
-    return getPairFromMarket(currentMarket, getCurrencySymbol)
-  }),
-)
+    const isPaperMarket = getIsPaperPair(symbol)
+    const marketTypeKey = isPaperMarket
+      ? MARKET_TYPES_KEYS.SANDBOX_MARKETS
+      : MARKET_TYPES_KEYS.LIVE_MARKETS
+    const currentMarket = _get(markets, `${marketTypeKey}.${symbol}`, null)
 
-export const getExecutionMarketPair = createSelector(
-  [getMarketsForExecution, getCurrencySymbolMemo],
-  (markets, getCurrencySymbol) => memoizeOne((symbol) => {
-    const currentMarket = markets?.[symbol]
-    if (_isEmpty(currentMarket)) {
-      return 'N/A'
+    if (!currentMarket) {
+      return symbol
     }
 
     return getPairFromMarket(currentMarket, getCurrencySymbol)

--- a/src/redux/selectors/meta/index.js
+++ b/src/redux/selectors/meta/index.js
@@ -2,7 +2,6 @@ import {
   getMarkets,
   getMarketPair,
   getMarketsForExecution,
-  getExecutionMarketPair,
   getMarketsSortedByVolumeForExecution,
 } from './get_markets'
 import getMarketBySymbol from './get_market_by_symbol'
@@ -13,7 +12,6 @@ import getTickersArray from './get_tickers_array'
 export {
   getMarkets,
   getMarketPair,
-  getExecutionMarketPair,
   getMarketsForExecution,
   getMarketsSortedByVolumeForExecution,
   getMarketBySymbol,

--- a/src/util/market.js
+++ b/src/util/market.js
@@ -3,11 +3,20 @@ import _first from 'lodash/first'
 import _get from 'lodash/get'
 import _includes from 'lodash/includes'
 import _replace from 'lodash/replace'
-import { ALLOWED_PAPER_PAIRS, MAIN_MODE, PAPER_MODE } from '../redux/reducers/ui'
+import _isObject from 'lodash/isObject'
+import {
+  ALLOWED_PAPER_PAIRS,
+  MAIN_MODE,
+  PAPER_MODE,
+} from '../redux/reducers/ui'
 
 export const getDefaultMarket = (markets) => _get(markets, [_first(_keys(markets))], 'uiID')
 
-export const getPairFromMarket = (market, getCurrencySymbol, divider = '/') => (market?.isPerp ? market.uiID : `${getCurrencySymbol(market?.base)}${divider}${getCurrencySymbol(market?.quote)}`)
+export const getPairFromMarket = (market, getCurrencySymbol, divider = '/') => (market?.isPerp
+  ? market.uiID
+  : `${getCurrencySymbol(market?.base)}${divider}${getCurrencySymbol(
+    market?.quote,
+  )}`)
 
 export const getCorrectIconNameOfPerpCcy = (perpCcy) => {
   const perpSuffix = 'F0'
@@ -19,4 +28,4 @@ export const getCorrectIconNameOfPerpCcy = (perpCcy) => {
 
 export const getStrategyModeForSymbol = (symbol) => (_includes(ALLOWED_PAPER_PAIRS, symbol?.wsID) ? PAPER_MODE : MAIN_MODE)
 
-export const getIsPaperPair = (symbol) => _includes(ALLOWED_PAPER_PAIRS, symbol?.wsID)
+export const getIsPaperPair = (symbol) => _includes(ALLOWED_PAPER_PAIRS, _isObject(symbol) ? symbol?.wsID : symbol)


### PR DESCRIPTION
### Asana task:
https://app.asana.com/0/1200372033300327/1202860763490991

### Description:
One selector for paper/trading pairs, which properly works regardless of the mode. If pair is not found, return initial `symbol` (not 'undefined/undefined', or 'N/A'). Removed `getExecutionMarketPair` as it becomes unused.
![Снимок экрана от 2022-08-25 12-00-04](https://user-images.githubusercontent.com/81973123/186623283-c39507cd-34e5-4d65-9ce8-82de20e2e7c3.png)


### Related Pull Requests:
...

### Backend Dependencies:
...

### Other Dependencies:
...

