### PR TITLE
(fix) Display strategies irrespective of the beta flag

### DIFF
--- a/src/components/HFUI/HFUI.container.js
+++ b/src/components/HFUI/HFUI.container.js
@@ -9,8 +9,6 @@ import {
   getCurrentMode,
   getShowAlgoPauseInfoSetting,
   getThemeSetting,
-  getIsBetaVersion,
-  getIsStrategiesTabVisible,
   SETTINGS_KEYS,
 } from '../../redux/selectors/ui'
 import { MAX_ORDER_COUNT_SETTING } from '../../redux/selectors/ui/get_core_settings'
@@ -31,7 +29,6 @@ const mapStateToProps = (state = {}) => {
     settingsShowAlgoPauseInfo: getShowAlgoPauseInfoSetting(state),
     settingsTheme: getThemeSetting(state),
     isBfxConnected: getIsBitfinexConnected(state),
-    showStrategies: getIsBetaVersion(state) || getIsStrategiesTabVisible(state),
   }
 }
 

--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -43,7 +43,6 @@ const HFUI = (props) => {
     settingsShowAlgoPauseInfo,
     settingsTheme,
     isBfxConnected,
-    showStrategies,
     getPastStrategies,
     openAppSettingsModal,
     setApplicationHiddenStatus,
@@ -160,7 +159,7 @@ const HFUI = (props) => {
               render={() => <TradingPage />}
               exact
             />
-            {showStrategies && Routes.strategyEditor && (
+            {isElectronApp && (
               <Route
                 path={Routes.strategyEditor.path}
                 render={() => <StrategiesPage />}
@@ -205,7 +204,6 @@ HFUI.propTypes = {
   settingsShowAlgoPauseInfo: PropTypes.bool,
   settingsTheme: PropTypes.oneOf([THEMES.LIGHT, THEMES.DARK]),
   isBfxConnected: PropTypes.bool,
-  showStrategies: PropTypes.bool,
   openAppSettingsModal: PropTypes.func.isRequired,
   setApplicationHiddenStatus: PropTypes.func.isRequired,
   updateFullscreenState: PropTypes.func.isRequired,
@@ -216,7 +214,6 @@ HFUI.defaultProps = {
   settingsShowAlgoPauseInfo: true,
   settingsTheme: THEMES.DARK,
   isBfxConnected: false,
-  showStrategies: false,
 }
 
 export default HFUI

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -19,7 +19,7 @@ import AppSettings from './Navbar.AppSettings'
 import Routes, { strategyEditor } from '../../constants/routes'
 import { isElectronApp } from '../../redux/config'
 import {
-  getThemeSetting, THEMES, getIsPaperTrading, getIsBetaVersion, getIsStrategiesTabVisible,
+  getThemeSetting, THEMES, getIsPaperTrading,
 } from '../../redux/selectors/ui'
 import { UI_MODAL_KEYS } from '../../redux/constants/modals'
 
@@ -46,9 +46,6 @@ const Navbar = () => {
   const { t } = useTranslation()
   const settingsTheme = useSelector(getThemeSetting)
   const isPaperTrading = useSelector(getIsPaperTrading)
-  const isBetaVersion = useSelector(getIsBetaVersion)
-  const isStrategiesTabVisible = useSelector(getIsStrategiesTabVisible)
-  const showStrategies = isBetaVersion || isStrategiesTabVisible
   const leafOptions = useMemo(() => getLeafDropdownOptions(settingsTheme), [settingsTheme])
 
   return (
@@ -56,16 +53,18 @@ const Navbar = () => {
       <HFIcon className='hfui-navbar__logo' fill={settingsTheme === THEMES.DARK ? 'white' : 'black'} />
       <ul className='hfui-navbar__main-links'>
         {_map(_values(Routes), ({ path, label }) => {
-          return showStrategies || path !== strategyEditor.path
-            ? (
-              <li key={path}>
-                <NavbarLink
-                  route={path}
-                  label={t(label, { paperPrefix: isPaperTrading ? t('main.paperPrefix') : null })}
-                />
-              </li>
-            )
-            : null
+          if (!isElectronApp && path === strategyEditor.path) {
+            return null
+          }
+
+          return (
+            <li key={path}>
+              <NavbarLink
+                route={path}
+                label={t(label, { paperPrefix: isPaperTrading ? t('main.paperPrefix') : null })}
+              />
+            </li>
+          )
         })}
       </ul>
       <div className='hfui-tradingpage__menu'>

--- a/src/components/OrderForm/OrderForm.container.js
+++ b/src/components/OrderForm/OrderForm.container.js
@@ -29,7 +29,6 @@ import {
   getIsPaperTrading,
   getMaxOrderCounts,
   getIsBetaVersion,
-  getIsStrategiesLiveExecVisible,
   getUIState,
 } from '../../redux/selectors/ui'
 import { getScope } from '../../util/scope'
@@ -67,8 +66,7 @@ const mapStateToProps = (state = {}, ownProps = {}) => {
     aoParams: getAOParams(state),
     maxOrderCounts: getMaxOrderCounts(state),
     isBetaVersion: getIsBetaVersion(state),
-    showAdvancedAlgos:
-      getIsStrategiesLiveExecVisible(state) || getIsBetaVersion(state),
+    showAdvancedAlgos: getIsBetaVersion(state),
   }
 }
 

--- a/src/components/StrategyEditor/StrategyEditor.container.js
+++ b/src/components/StrategyEditor/StrategyEditor.container.js
@@ -16,8 +16,6 @@ import {
 import {
   getThemeSetting,
   getIsPaperTrading,
-  getStrategiesFeatureFlags,
-  getIsBetaVersion,
   getCurrentMode,
   getStrategyExecutionId,
   getServicesStatus,
@@ -34,8 +32,6 @@ const mapStateToProps = (state = {}) => {
     executionState: getCurrentStrategyExecutionState(state),
     settingsTheme: getThemeSetting(state),
     isPaperTrading: getIsPaperTrading(state),
-    flags: getStrategiesFeatureFlags(state),
-    isBetaVersion: getIsBetaVersion(state),
     savedStrategies: getSavedStrategies(state),
     currentMode: getCurrentMode(state),
     executionId: getStrategyExecutionId(state),

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -81,8 +81,6 @@ const StrategyEditor = (props) => {
     isPaperTrading,
     dsExecuteBacktest,
     showError,
-    flags,
-    isBetaVersion,
     executionState,
     sectionErrors,
     savedStrategies,
@@ -100,43 +98,43 @@ const StrategyEditor = (props) => {
 
   const [isRemoveModalOpen, , openRemoveModal, closeRemoveModal] = useToggle(false)
   const [
-    createNewStrategyModalOpen,,
+    createNewStrategyModalOpen, ,
     openCreateNewStrategyModal,
     closeCreateNewStrategyModal,
   ] = useToggle(false)
   const [
-    createNewStrategyFromModalOpened,,
+    createNewStrategyFromModalOpened, ,
     openCreateNewStrategyFromModal,
     closeCreateNewStrategyFromModal,
   ] = useToggle(false)
   const [isOpenExistingStrategyModalOpen, , , closeOpenExistingStrategyModal] = useToggle(false)
   const [
-    isSaveStrategyAsModalOpen,,
+    isSaveStrategyAsModalOpen, ,
     openSaveStrategyAsModal,
     closeSaveStrategyAsModal,
   ] = useToggle(false)
   const [
-    isEditStrategyLabelModalOpen,,
+    isEditStrategyLabelModalOpen, ,
     openEditStrategyLabelModal,
     closeEditStrategyLabelModal,
   ] = useToggle(false)
   const [
-    isSaveStrategyBeforeLaunchModalOpen,,
+    isSaveStrategyBeforeLaunchModalOpen, ,
     openSaveStrategyBeforeLaunchModal,
     closeSaveStrategyBeforeLaunchModal,
   ] = useToggle(false)
   const [
-    isCancelProcessModalOpen,,
+    isCancelProcessModalOpen, ,
     openCancelProcessModal,
     closeCancelProcessModal,
   ] = useToggle(false)
   const [
-    isStrategySettingsModalOpen,,
+    isStrategySettingsModalOpen, ,
     openStrategySettingsModal,
     closeStrategySettingsModal,
   ] = useToggle(false)
   const [
-    isLaunchStrategyModalOpen,,
+    isLaunchStrategyModalOpen, ,
     openLaunchStrategyModal,
     closeLaunchStrategyModal,
   ] = useToggle(false)
@@ -642,23 +640,21 @@ const StrategyEditor = (props) => {
             removeable={removeable}
             onRemoveStrategy={onRemoveStrategy}
           >
-            {(isBetaVersion || flags?.live_execution) && (
-              <StrategyTab
-                htmlKey='strategy'
-                sbtitle={sbtitleStrategy}
-                onOpenSaveStrategyAsModal={openSaveStrategyAsModal}
-                onOpenEditStrategyLabelModal={openEditStrategyLabelModal}
-                isPaperTrading={isPaperTrading}
-                stopExecution={stopExecution}
-                onSaveStrategy={onSaveStrategy}
-                saveStrategyOptions={saveStrategyOptions}
-                hasErrors={hasErrorsInIDE}
-                onCancelProcess={onCancelProcess}
-                {...props}
-              />
-            )}
+            <StrategyTab
+              htmlKey='strategy'
+              sbtitle={sbtitleStrategy}
+              onOpenSaveStrategyAsModal={openSaveStrategyAsModal}
+              onOpenEditStrategyLabelModal={openEditStrategyLabelModal}
+              isPaperTrading={isPaperTrading}
+              stopExecution={stopExecution}
+              onSaveStrategy={onSaveStrategy}
+              saveStrategyOptions={saveStrategyOptions}
+              hasErrors={hasErrorsInIDE}
+              onCancelProcess={onCancelProcess}
+              {...props}
+            />
 
-            {isPaperTrading && (isBetaVersion || flags?.backtest) && (
+            {isPaperTrading ? (
               <BacktestTab
                 htmlKey='backtest'
                 sbtitle={sbtitleBacktest}
@@ -669,8 +665,7 @@ const StrategyEditor = (props) => {
                 openNewTest={openNewTest}
                 {...props}
               />
-            )}
-            {(isBetaVersion || flags?.docs) && !isPaperTrading && (
+            ) : (
               <IDETab
                 htmlKey='view_in_ide'
                 key='view_in_ide'
@@ -687,14 +682,12 @@ const StrategyEditor = (props) => {
                 strategy={strategy}
               />
             )}
-            {(isBetaVersion || flags?.live_execution) && (
-              <div
-                htmlKey='settings'
-                key='settings'
-                sbtitle={sbtitleSettings}
-                onClick={openStrategySettingsModal}
-              />
-            )}
+            <div
+              htmlKey='settings'
+              key='settings'
+              sbtitle={sbtitleSettings}
+              onClick={openStrategySettingsModal}
+            />
           </StrategyEditorPanel>
           <RemoveExistingStrategyModal
             isOpen={isRemoveModalOpen}
@@ -792,12 +785,6 @@ StrategyEditor.propTypes = {
   saveStrategy: PropTypes.func.isRequired,
   isPaperTrading: PropTypes.bool.isRequired,
   dsExecuteBacktest: PropTypes.func.isRequired,
-  isBetaVersion: PropTypes.bool.isRequired,
-  flags: PropTypes.shape({
-    docs: PropTypes.bool,
-    live_execution: PropTypes.bool,
-    backtest: PropTypes.bool,
-  }).isRequired,
   showError: PropTypes.func.isRequired,
   sectionErrors: PropTypes.objectOf(PropTypes.string).isRequired,
   cancelProcess: PropTypes.func.isRequired,
@@ -819,7 +806,7 @@ StrategyEditor.propTypes = {
 StrategyEditor.defaultProps = {
   moveable: false,
   removeable: false,
-  setStrategy: () => {},
+  setStrategy: () => { },
   strategy: {
     id: null,
     label: null,

--- a/src/redux/selectors/ui/get_feature_flags.js
+++ b/src/redux/selectors/ui/get_feature_flags.js
@@ -1,25 +1,8 @@
 import _get from 'lodash/get'
-import _some from 'lodash/some'
-import { createSelector } from 'reselect'
 import { REDUCER_PATHS } from '../../config'
 
 const path = REDUCER_PATHS.UI
 
 export const getFeatureFlags = (state) => _get(state, `${path}.featureFlags`)
-
-export const getStrategiesFeatureFlags = createSelector(
-  getFeatureFlags,
-  (allFlags) => allFlags?.strategy_editor,
-)
-
-export const getIsStrategiesLiveExecVisible = createSelector(
-  getStrategiesFeatureFlags,
-  (strategiesFlags) => strategiesFlags?.live_execution,
-)
-
-export const getIsStrategiesTabVisible = createSelector(
-  getStrategiesFeatureFlags,
-  (strategiesFlags) => _some(strategiesFlags, flag => flag === true),
-)
 
 export default getFeatureFlags


### PR DESCRIPTION
### Asana task:
[(bug) Strategies are not beta features anymore](https://app.asana.com/0/1201849173362898/1203097856141613/f)

### Description:
Now strategies are available for all Honey electron-version users.
