### PR TITLE
(fix) NPM install crashes with peer dependency related error

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-ga4": "^1.4.1",
     "react-grid-layout": "^1.3.4",
     "react-i18next": "^11.18.6",
-    "react-monaco-editor": "^0.45.0",
+    "@blaumaus/react-monaco-editor": "^0.45.0",
     "react-outside-click-handler": "^1.3.0",
     "react-perfect-scrollbar": "^1.5.8",
     "react-redux": "^8.0.4",

--- a/src/components/StrategyEditor/components/MonacoEditor.js
+++ b/src/components/StrategyEditor/components/MonacoEditor.js
@@ -1,4 +1,4 @@
-import Editor, { monaco } from 'react-monaco-editor'
+import Editor, { monaco } from '@blaumaus/react-monaco-editor'
 import React, { useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'


### PR DESCRIPTION
### Asana task:
https://github.com/bitfinexcom/bfx-hf-ui-core/issues/554

### Description:
v0.45.0 version of `react-monaco-editor` (which is the latest version that works with webpack 4) is set to react ^17 as a peer dependency.
Later versions of this package support react ^18, but they require webpack 5.
Until we update to webpack 5 or start using regular react-scripts, `@blaumaus/react-monaco-editor` can be used as an alternative (it provides same version as the original package, but with the support of react ^18 as a peer dependency).