### PR TITLE
(fix) Strategy Editor -> Spanish and Portuguese language overflows into 2 rows

### DIFF
--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -153,7 +153,6 @@ const StrategyEditor = (props) => {
     return language === LANGUAGES.es || language === LANGUAGES.pt
   }, [language])
 
-  console.log(isWideSidebar)
 
   const {
     symbol,

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -57,6 +57,7 @@ import EditStrategyLabelModal from '../../modals/Strategy/EditStrategyLabelModal
 import { UI_MODAL_KEYS } from '../../redux/constants/modals'
 import { PAPER_MODE } from '../../redux/reducers/ui'
 import SettingsTitle from './tabs/SettingsTitle'
+import { LANGUAGES } from '../../locales/i18n'
 
 import './style.css'
 
@@ -96,7 +97,7 @@ const StrategyEditor = (props) => {
     setSectionErrors,
     serviceStatus,
   } = props
-  const { t } = useTranslation()
+  const { t, i18n: { language } } = useTranslation()
 
   const [isRemoveModalOpen, , openRemoveModal, closeRemoveModal] = useToggle(false)
   const [
@@ -147,6 +148,12 @@ const StrategyEditor = (props) => {
     'strategyOptions',
     getDefaultStrategyOptions(),
   )
+
+  const isWideSidebar = useMemo(() => {
+    return language === LANGUAGES.es || language === LANGUAGES.pt
+  }, [language])
+
+  console.log(isWideSidebar)
 
   const {
     symbol,
@@ -641,6 +648,7 @@ const StrategyEditor = (props) => {
             moveable={moveable}
             removeable={removeable}
             onRemoveStrategy={onRemoveStrategy}
+            isWideSidebar={isWideSidebar}
           >
             {(isBetaVersion || flags?.live_execution) && (
               <StrategyTab

--- a/src/components/StrategyEditor/components/StrategyEditorPanel.js
+++ b/src/components/StrategyEditor/components/StrategyEditorPanel.js
@@ -5,7 +5,7 @@ import Panel from '../../../ui/Panel'
 import '../style.css'
 
 const StrategyEditorPanel = ({
-  moveable, children, removeable,
+  moveable, children, removeable, isWideSidebar,
 }) => {
   return (
     <Panel
@@ -14,6 +14,7 @@ const StrategyEditorPanel = ({
       darkHeader
       moveable={moveable}
       removeable={removeable}
+      isWideSidebar={isWideSidebar}
     >
       {children}
     </Panel>
@@ -24,11 +25,13 @@ StrategyEditorPanel.propTypes = {
   moveable: PropTypes.bool,
   removeable: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  isWideSidebar: PropTypes.bool,
 }
 
 StrategyEditorPanel.defaultProps = {
   moveable: true,
   removeable: true,
+  isWideSidebar: false,
 }
 
 export default memo(StrategyEditorPanel)

--- a/src/ui/Panel/Panel.js
+++ b/src/ui/Panel/Panel.js
@@ -47,6 +47,7 @@ const Panel = ({
   fullscreen,
   onEnterFullscreen,
   onExitFullscreen,
+  isWideSidebar,
 }) => {
   const tabs = _filter(
     React.Children.toArray(children),
@@ -221,7 +222,11 @@ const Panel = ({
               'no-sidebar': _isEmpty(sbTabs),
             })}
           >
-            <div className='hfui_panel__sidebar-container'>
+            <div
+              className={ClassNames('hfui_panel__sidebar-container', {
+                wide: isWideSidebar,
+              })}
+            >
               <Icon
                 className='hfui_panel__sidebar_switch'
                 name={sidebarOpened ? 'chevron-left' : 'chevron-right'}
@@ -295,6 +300,7 @@ Panel.propTypes = {
   fullscreen: PropTypes.bool,
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
+  isWideSidebar: PropTypes.bool,
 }
 
 Panel.defaultProps = {
@@ -325,6 +331,7 @@ Panel.defaultProps = {
   fullscreen: false,
   onEnterFullscreen: () => {},
   onExitFullscreen: () => {},
+  isWideSidebar: false,
 }
 
 export default Panel

--- a/src/ui/Panel/style.scss
+++ b/src/ui/Panel/style.scss
@@ -318,6 +318,10 @@
     &.sidebar-opened {
       .hfui_panel__sidebar-container {
         width: 155px;
+
+        &.wide {
+          width: 190px;
+        }
       }
     }
 


### PR DESCRIPTION
### Asana task:
https://app.asana.com/0/1201849173362898/1203106903675979/f

### UI Demonstration:
<img width="676" alt="Screenshot 2022-11-02 at 11 17 40" src="https://user-images.githubusercontent.com/35810911/199465017-7980a81b-c05c-4859-aaac-75bb4bd298e4.png">
<img width="708" alt="Screenshot 2022-11-02 at 11 17 26" src="https://user-images.githubusercontent.com/35810911/199465029-2c044aed-64f2-451d-ab52-e6fe36609c95.png">
<img width="720" alt="Screenshot 2022-11-02 at 11 07 13" src="https://user-images.githubusercontent.com/35810911/199465037-825e2120-7aa1-400e-b290-beb33fb3c926.png">
