### PR TITLE
(fix) Position p/l value for chart

### DIFF
--- a/src/util/chart.js
+++ b/src/util/chart.js
@@ -178,7 +178,7 @@ export const getPositionTooltip = (position, args) => {
   }))
 
   tooltipLines.push(t('chart.trading.position.tooltip.pl', {
-    pl: setSigFig(position.realizedPnl),
+    pl: setSigFig(position.realizedPnl || position.pl),
     ccy: quote,
   }))
 


### PR DESCRIPTION
### Asana task:
[Positions chart info do not display P/L](https://app.asana.com/0/1201849173362898/1202985731266205/f)

### UI Demonstration:
<img width="719" alt="Screenshot 2022-11-15 at 18 31 45" src="https://user-images.githubusercontent.com/35810911/201998532-1b64ad7b-e061-490a-99a8-b2ce11475761.png">
