### PR TITLE
(fix) Backtest: Last quarter can't be selected

### DIFF
--- a/src/components/BacktestOptionsPanel/BacktestOptionsPanel.js
+++ b/src/components/BacktestOptionsPanel/BacktestOptionsPanel.js
@@ -68,7 +68,8 @@ const BacktestOptionsPanel = ({
 
   const timePeriod = useMemo(() => {
     const diff = endDate.getTime() - startDate.getTime()
-    const diffHours = Math.ceil(diff / (1000 * 60 * 60))
+    // Apparently the dates sometimes overlap on Chrome so there's a few extra hours in the diff, let's subtract them.
+    const diffHours = Math.ceil(diff / (1000 * 60 * 60)) - 2
 
     if (diffHours <= TIME_MAPPING['168h']) {
       return '168h'


### PR DESCRIPTION
### Asana task:
[REOPEN: Change Backtest periods for "custom date" selector](https://app.asana.com/0/1201849173362898/1203432924647300/f)