### PR TITLE
(improvement) Thin 'history' icon

### DIFF
--- a/src/components/AlgoOrdersHistoryButton/AlgoOrdersHistoryButton.js
+++ b/src/components/AlgoOrdersHistoryButton/AlgoOrdersHistoryButton.js
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from 'react'
-import Icon from 'react-fa'
 import _toUpper from 'lodash/toUpper'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -10,6 +9,7 @@ import { getShowAOsHistory } from '../../redux/selectors/ao'
 import { getIsAOsHistoryLoaded } from '../../redux/selectors/ws'
 import AOActions from '../../redux/actions/ao'
 import useToggle from '../../hooks/useToggle'
+import HistoryIcon from '../../ui/Icons/HistoryIcon'
 
 import './style.css'
 
@@ -70,7 +70,7 @@ const AlgoOrdersHistoryButton = () => {
         isHistoryLoading ? (
           <Spinner className='hfui-history-button__spinner' />
         ) : (
-          <Icon name='history' className='hfui-history-button__icon' />
+          <HistoryIcon className='hfui-history-button__icon' width='25px' height='25px' />
         )
       }
     />

--- a/src/ui/Icons/HistoryIcon.js
+++ b/src/ui/Icons/HistoryIcon.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const HistoryIcon = ({ ...props }) => (
+  <svg viewBox='0 0 24 24' {...props}>
+    <path
+      fill='currentColor'
+      d='M13.5 8H12v5l4.28 2.54l.72-1.21l-3.5-2.08V8M13 3a9 9 0 0 0-9 9H1l3.96 4.03L9 12H6a7 7 0 0 1 7-7a7 7 0 0 1 7 7a7 7 0 0 1-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42A8.896 8.896 0 0 0 13 21a9 9 0 0 0 9-9a9 9 0 0 0-9-9'
+    />
+  </svg>
+)
+
+export default HistoryIcon


### PR DESCRIPTION
### Asana task:
[Replace Trading State history icon](https://app.asana.com/0/1201848935859401/1203856519336818/f)

### UI Demonstration:
<img width="229" alt="Screenshot 2023-02-14 at 21 03 04" src="https://user-images.githubusercontent.com/35810911/218862468-a672c2e7-95c6-41d4-a4a0-dfaf7a3cbdd3.png">
