### PR TITLE
(improvement) Improve Trading State Filtering

### DIFF
--- a/src/components/MarketSelect/style.scss
+++ b/src/components/MarketSelect/style.scss
@@ -1,7 +1,7 @@
 @import '../../variables.scss';
 
 .hfui-marketselect {
-  min-width: 185px !important;
+  min-width: 185px;
 
   li {
     margin: 0 !important;

--- a/src/components/TradingStatePanel/TradingStatePanel.container.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.container.js
@@ -6,6 +6,7 @@ import {
   getFilteredAtomicOrdersCount,
   getFilteredAlgoOrdersCount,
   getAuthToken,
+  getCurrentModeAlgoOrders,
 } from '../../redux/selectors/ws'
 import { getMarkets } from '../../redux/selectors/meta'
 import UIActions from '../../redux/actions/ui'
@@ -19,6 +20,7 @@ const mapStateToProps = (state = {}, { layoutID, layoutI: id } = {}) => ({
   getPositionsCount: getFilteredPositionsCount(state),
   getAtomicOrdersCount: getFilteredAtomicOrdersCount(state),
   getAlgoOrdersCount: getFilteredAlgoOrdersCount(state),
+  algoOrders: getCurrentModeAlgoOrders(state),
   markets: getMarkets(state),
   savedState: getComponentState(state, layoutID, 'trading_state', id),
   getCurrencySymbol: reduxSelectors.getCurrencySymbolMemo(state),

--- a/src/components/TradingStatePanel/TradingStatePanel.container.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.container.js
@@ -7,6 +7,8 @@ import {
   getFilteredAlgoOrdersCount,
   getAuthToken,
   getCurrentModeAlgoOrders,
+  getAllPositions,
+  getAtomicOrders,
 } from '../../redux/selectors/ws'
 import { getMarkets } from '../../redux/selectors/meta'
 import UIActions from '../../redux/actions/ui'
@@ -21,6 +23,8 @@ const mapStateToProps = (state = {}, { layoutID, layoutI: id } = {}) => ({
   getAtomicOrdersCount: getFilteredAtomicOrdersCount(state),
   getAlgoOrdersCount: getFilteredAlgoOrdersCount(state),
   algoOrders: getCurrentModeAlgoOrders(state),
+  positions: getAllPositions(state),
+  atomicOrders: getAtomicOrders(state),
   markets: getMarkets(state),
   savedState: getComponentState(state, layoutID, 'trading_state', id),
   getCurrencySymbol: reduxSelectors.getCurrencySymbolMemo(state),

--- a/src/components/TradingStatePanel/TradingStatePanel.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.js
@@ -118,6 +118,7 @@ const TradingStatePanel = ({
                   renderWithFavorites
                   ref={marketRef}
                   placeholder={t('tradingStatePanel.filterBy')}
+                  className='hfui-tradingstatepanel__options-market-select'
                 />
               </div>
               {!showMarketDropdown && (

--- a/src/components/TradingStatePanel/TradingStatePanel.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.js
@@ -4,6 +4,10 @@ import React, {
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import _get from 'lodash/get'
+import _pickBy from 'lodash/pickBy'
+import _map from 'lodash/map'
+import _values from 'lodash/values'
+import _includes from 'lodash/includes'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -16,7 +20,7 @@ import AtomicOrdersTable from '../AtomicOrdersTable'
 import AlgoOrdersTable from '../AlgoOrdersTable'
 import BalancesTable from '../BalancesTable'
 import MarketSelect from '../MarketSelect'
-import { MARKET_SHAPE } from '../../constants/prop-types-shapes'
+import { MARKET_SHAPE, ORDER_SHAPE } from '../../constants/prop-types-shapes'
 import PanelButton from '../../ui/Panel/Panel.Button'
 import CCYIcon from '../../ui/CCYIcon'
 import AlgoOrdersHistoryButton from '../AlgoOrdersHistoryButton'
@@ -38,6 +42,7 @@ const TradingStatePanel = ({
   layoutI,
   getCurrencySymbol,
   currentMode,
+  algoOrders,
 }) => {
   const currentMarket = _get(savedState, 'currentMarket', {})
   const activeFilter = _get(currentMarket, currentMode, {})
@@ -61,6 +66,14 @@ const TradingStatePanel = ({
     },
     [saveState],
   )
+
+  const filterableMarkets = useMemo(() => {
+    const algoOrderSymbols = _map(_values(algoOrders), 'args.symbol')
+    const filteredMarkets = _pickBy(markets, (_, key) => {
+      return _includes(algoOrderSymbols, key)
+    })
+    return filteredMarkets
+  }, [markets, algoOrders])
 
   const setActiveFilter = (market) => {
     saveState('currentMarket', {
@@ -112,7 +125,7 @@ const TradingStatePanel = ({
             <Fragment key='filter-market'>
               <div style={styles}>
                 <MarketSelect
-                  markets={markets}
+                  markets={filterableMarkets}
                   value={activeFilter}
                   onChange={setActiveFilter}
                   renderWithFavorites
@@ -181,6 +194,7 @@ TradingStatePanel.propTypes = {
   getAtomicOrdersCount: PropTypes.func,
   getAlgoOrdersCount: PropTypes.func,
   markets: PropTypes.objectOf(PropTypes.shape(MARKET_SHAPE)).isRequired,
+  algoOrders: PropTypes.objectOf(PropTypes.shape(ORDER_SHAPE)).isRequired,
   savedState: PropTypes.shape({
     currentMarket: PropTypes.shape(MARKET_SHAPE),
     tab: PropTypes.number,

--- a/src/components/TradingStatePanel/style.scss
+++ b/src/components/TradingStatePanel/style.scss
@@ -35,6 +35,10 @@
     padding-top: 2px;
     margin-right: 5px;
   }
+
+  &-market-select {
+    max-width: 120px !important;
+  }
 }
 
 .hfui-tradingstatepanel__ccy-icon {


### PR DESCRIPTION
### Asana task:
[Improve Trading State Filtering](https://app.asana.com/0/1201849173362898/1203856519336806/f)

### Checklist:
 - [x] The filter should have a smaller width, since there's no pair that reaches the current width and this would prevent the stacking
 - [x] We should only populate the filter with the pairs present in the lists, this is valid for Atomics, Positions and AOs

### UI Demonstration:

https://user-images.githubusercontent.com/35810911/218868401-daa8c17d-9138-4689-a2ae-2145ddb2660a.mov

<img width="709" alt="Screenshot 2023-02-14 at 21 46 37" src="https://user-images.githubusercontent.com/35810911/218870494-59a492f6-2221-47bb-abe5-abea4590d4ab.png">


