### PR TITLE
(fix) Trading State: market dropdown / history button do not fit into the component

### DIFF
--- a/src/components/TradingStatePanel/style.scss
+++ b/src/components/TradingStatePanel/style.scss
@@ -19,7 +19,7 @@
   padding: 0 12px;
 
   & > *:not(:last-child) {
-    margin-right: 10px;
+    margin-right: 5px;
   }
 
   .filter-by {
@@ -36,8 +36,14 @@
     margin-right: 5px;
   }
 
+  .hfui-panel__button {
+    padding-right: 4px;
+    padding-left: 3px;
+  }
+
   &-market-select {
-    max-width: 120px !important;
+    max-width: 165px !important;
+    min-width: 165px;
   }
 }
 


### PR DESCRIPTION
### Asana task:
https://app.asana.com/0/1201849173362898/1203856519336806

### Description:
<img width="842" alt="Screenshot 2023-02-28 at 16 38 34" src="https://user-images.githubusercontent.com/35810911/221918890-4d0466be-1fb2-440a-82ca-7b42bbc7f6de.png">
Decreased the max width of market selector and history button. If user shrinks the component they will still be moved on the next row, but by default the options should fit into the component now.