### PR TITLE
(improvement) AlgoOrders behaviour

### DIFF
--- a/src/components/AlgoOrdersTable/AlgoOrderActions.js
+++ b/src/components/AlgoOrdersTable/AlgoOrderActions.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import Debug from 'debug'
 import { Tooltip } from '@ufx-ui/core'
@@ -15,10 +15,15 @@ import { UI_KEYS } from '../../redux/constants/ui_keys'
 import { getAuthToken } from '../../redux/selectors/ws'
 import { ORDER_SHAPE } from '../../constants/prop-types-shapes'
 import { LOG_LEVELS } from '../../constants/logging'
+import PanelIconButton from '../../ui/Panel/Panel.IconButton'
 
 const debug = Debug('hfui:c:algo-order-action')
 
-const AlgoOrderActions = ({ order }) => {
+const AlgoOrderActions = ({
+  order,
+  isInAlgoOrderDetailsModal,
+}) => {
+  const tooltipRef = useRef(null)
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const authToken = useSelector(getAuthToken)
@@ -27,8 +32,15 @@ const AlgoOrderActions = ({ order }) => {
 
   const cancelOrder = () => {
     debug('cancelling algo order %d', gid)
+
     dispatch(WSActions.send(['algo_order.cancel', authToken, 'bitfinex', gid]))
-    dispatch(UIActions.logInformation(`User requested the cancellation of algorithmic order with ID ${id}`, LOG_LEVELS.INFO, 'ao_cancelled'))
+    dispatch(
+      UIActions.logInformation(
+        `User requested the cancellation of algorithmic order with ID ${id}`,
+        LOG_LEVELS.INFO,
+        'ao_cancelled',
+      ),
+    )
   }
 
   const gaCancelOrder = () => {
@@ -40,12 +52,15 @@ const AlgoOrderActions = ({ order }) => {
     dispatch(
       UIActions.changeUIModalState(UI_MODAL_KEYS.EDIT_ORDER_MODAL, true),
     )
+    // when option selected and EditOrderModal appears, the Tooltip component should be hidden
+    tooltipRef?.current?.hideTooltip?.()
   }
 
   return (
     <div className='hfui-ao-actions'>
       <Tooltip
         className='tooltip__edit-order-menu'
+        ref={tooltipRef}
         trigger='click'
         content={(
           <div className='hfui-navbar__layout-settings__menu-buttons'>
@@ -61,11 +76,18 @@ const AlgoOrderActions = ({ order }) => {
           </div>
         )}
       >
-        <Icon
-          className='more-options-button'
-          name='ellipsis-v'
-          aria-label='More options'
-        />
+        {isInAlgoOrderDetailsModal ? (
+          <PanelIconButton
+            onClick={() => {}}
+            icon={<Icon name='ellipsis-v' aria-label='More options' />}
+          />
+        ) : (
+          <Icon
+            className='more-options-button'
+            name='ellipsis-v'
+            aria-label='More options'
+          />
+        )}
       </Tooltip>
     </div>
   )
@@ -73,6 +95,11 @@ const AlgoOrderActions = ({ order }) => {
 
 AlgoOrderActions.propTypes = {
   order: PropTypes.shape(ORDER_SHAPE).isRequired,
+  isInAlgoOrderDetailsModal: PropTypes.bool,
+}
+
+AlgoOrderActions.defaultProps = {
+  isInAlgoOrderDetailsModal: false,
 }
 
 export default AlgoOrderActions

--- a/src/components/AlgoOrdersTable/AlgoOrderActions.js
+++ b/src/components/AlgoOrdersTable/AlgoOrderActions.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Debug from 'debug'
+import { Tooltip } from '@ufx-ui/core'
+import { Icon } from 'react-fa'
+import { useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { Item } from '../Navbar/Navbar.LayoutSettings'
+import WSActions from '../../redux/actions/ws'
+import UIActions from '../../redux/actions/ui'
+import GAActions from '../../redux/actions/google_analytics'
+import { UI_MODAL_KEYS } from '../../redux/constants/modals'
+import { UI_KEYS } from '../../redux/constants/ui_keys'
+import { getAuthToken } from '../../redux/selectors/ws'
+import { ORDER_SHAPE } from '../../constants/prop-types-shapes'
+import { LOG_LEVELS } from '../../constants/logging'
+
+const debug = Debug('hfui:c:algo-order-action')
+
+const AlgoOrderActions = ({ order }) => {
+  const { t } = useTranslation()
+  const dispatch = useDispatch()
+  const authToken = useSelector(getAuthToken)
+
+  const { gid, id } = order
+
+  const cancelOrder = () => {
+    debug('cancelling algo order %d', gid)
+    dispatch(WSActions.send(['algo_order.cancel', authToken, 'bitfinex', gid]))
+    dispatch(UIActions.logInformation(`User requested the cancellation of algorithmic order with ID ${id}`, LOG_LEVELS.INFO, 'ao_cancelled'))
+  }
+
+  const gaCancelOrder = () => {
+    dispatch(GAActions.cancelAO())
+  }
+
+  const editOrder = () => {
+    dispatch(UIActions.setUIValue(UI_KEYS.orderToEdit, order))
+    dispatch(
+      UIActions.changeUIModalState(UI_MODAL_KEYS.EDIT_ORDER_MODAL, true),
+    )
+  }
+
+  return (
+    <div className='hfui-ao-actions'>
+      <Tooltip
+        className='tooltip__edit-order-menu'
+        trigger='click'
+        content={(
+          <div className='hfui-navbar__layout-settings__menu-buttons'>
+            <Item onClick={() => editOrder(order)}>{t('table.edit')}</Item>
+            <Item
+              onClick={() => {
+                cancelOrder()
+                gaCancelOrder()
+              }}
+            >
+              {t('table.cancelRemaining')}
+            </Item>
+          </div>
+        )}
+      >
+        <Icon
+          className='more-options-button'
+          name='ellipsis-v'
+          aria-label='More options'
+        />
+      </Tooltip>
+    </div>
+  )
+}
+
+AlgoOrderActions.propTypes = {
+  order: PropTypes.shape(ORDER_SHAPE).isRequired,
+}
+
+export default AlgoOrderActions

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.columns.js
@@ -1,21 +1,11 @@
 import React from 'react'
 import { Icon } from 'react-fa'
-import OutsideClickHandler from 'react-outside-click-handler'
 
 import { defaultCellRenderer } from '../../util/ui'
-import { Item } from '../Navbar/Navbar.LayoutSettings'
+import AlgoOrderActions from './AlgoOrderActions'
 
 export default ({
-  authToken,
-  cancelOrder,
-  gaCancelOrder,
-  t,
-  getMarketPair,
-  editOrder,
-  showActions,
-  activeOrderGID,
-  setActiveOrderGID,
-  setMoreInfoGID,
+  t, getMarketPair, showActions, setMoreInfoGID,
 }) => {
   const columns = [
     {
@@ -88,39 +78,7 @@ export default ({
       minWidth: 20,
       cellRenderer: (
         { rowData = {} } // eslint-disable-line
-      ) => (
-        <div className='icons-cell'>
-          <Icon
-            className='more-options-button'
-            name='ellipsis-v'
-            aria-label='More options'
-            onClick={() => rowData?.gid && setActiveOrderGID(rowData.gid)}
-          />
-
-          {activeOrderGID === rowData?.gid && (
-            <OutsideClickHandler onOutsideClick={() => setActiveOrderGID(null)}>
-              <div className='hfui-navbar__layout-settings__menu edit-order-menu'>
-                <div
-                  className='hfui-navbar__layout-settings__menu-buttons'
-                  onClick={() => setActiveOrderGID(null)}
-                >
-                  <Item onClick={() => editOrder(rowData)}>
-                    {t('table.edit')}
-                  </Item>
-                  <Item
-                    onClick={() => {
-                      cancelOrder(authToken, rowData)
-                      gaCancelOrder()
-                    }}
-                  >
-                    {t('table.cancelRemaining')}
-                  </Item>
-                </div>
-              </div>
-            </OutsideClickHandler>
-          )}
-        </div>
-      ),
+      ) => <AlgoOrderActions key={rowData.gid} order={rowData} />,
       disableSort: true,
     })
   }

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.container.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.container.js
@@ -1,26 +1,15 @@
 import { connect } from 'react-redux'
-import Debug from 'debug'
 
 import {
   getCurrentModeAlgoOrders,
   getFilteredAlgoOrders,
-  getAuthToken,
 } from '../../redux/selectors/ws'
 import { getActiveMarket } from '../../redux/selectors/ui'
-import WSActions from '../../redux/actions/ws'
-import UIActions from '../../redux/actions/ui'
-import GAActions from '../../redux/actions/google_analytics'
 import AlgoOrdersTable from './AlgoOrdersTable'
 import { getMarketPair } from '../../redux/selectors/meta'
-import { UI_MODAL_KEYS } from '../../redux/constants/modals'
-import { UI_KEYS } from '../../redux/constants/ui_keys'
 import { getShowAOsHistory } from '../../redux/selectors/ao'
-import { LOG_LEVELS } from '../../constants/logging'
-
-const debug = Debug('hfui:c:algo-orders-table')
 
 const mapStateToProps = (state = {}, { activeFilter }) => ({
-  authToken: getAuthToken(state),
   algoOrders: getCurrentModeAlgoOrders(state),
   filteredAlgoOrders: getFilteredAlgoOrders(state)(activeFilter),
   activeMarket: getActiveMarket(state),
@@ -28,23 +17,4 @@ const mapStateToProps = (state = {}, { activeFilter }) => ({
   showHistory: getShowAOsHistory(state),
 })
 
-const mapDispatchToProps = (dispatch) => ({
-  cancelOrder: (authToken, order) => {
-    const { gid, id } = order
-
-    debug('cancelling algo order %d', gid)
-    dispatch(WSActions.send(['algo_order.cancel', authToken, 'bitfinex', gid]))
-    dispatch(UIActions.logInformation(`User requested the cancellation of algorithmic order with ID ${id}`, LOG_LEVELS.INFO, 'ao_cancelled'))
-  },
-  gaCancelOrder: () => {
-    dispatch(GAActions.cancelAO())
-  },
-  editOrder: (order) => {
-    dispatch(UIActions.setUIValue(UI_KEYS.orderToEdit, order))
-    dispatch(
-      UIActions.changeUIModalState(UI_MODAL_KEYS.EDIT_ORDER_MODAL, true),
-    )
-  },
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)(AlgoOrdersTable)
+export default connect(mapStateToProps)(AlgoOrdersTable)

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.js
@@ -15,19 +15,13 @@ import './style.css'
 const AlgoOrdersTable = ({
   filteredAlgoOrders,
   algoOrders,
-  cancelOrder,
-  authToken,
-  gaCancelOrder,
   renderedInTradingState,
   getMarketPair,
-  editOrder,
   showHistory,
 }) => {
   const data = renderedInTradingState ? filteredAlgoOrders : algoOrders
   const { t } = useTranslation()
 
-  // Storing a null or an order ID here, indicates if Edit / Canel modal is opened for a specific row
-  const [activeOrderGID, setActiveOrderGID] = useState(null)
   // Indicates if the 'More info' modal is opened for a specific row
   const [moreInfoGID, setMoreInfoGID] = useState(null)
 
@@ -38,27 +32,12 @@ const AlgoOrdersTable = ({
 
   const AOColumns = useMemo(
     () => AlgoOrdersTableColumns({
-      authToken,
-      cancelOrder,
-      gaCancelOrder,
       t,
       getMarketPair,
-      editOrder,
       showActions: !showHistory,
-      activeOrderGID,
-      setActiveOrderGID,
       setMoreInfoGID,
     }),
-    [
-      activeOrderGID,
-      authToken,
-      cancelOrder,
-      editOrder,
-      gaCancelOrder,
-      getMarketPair,
-      showHistory,
-      t,
-    ],
+    [getMarketPair, showHistory, t],
   )
 
   return (
@@ -87,12 +66,8 @@ const AlgoOrdersTable = ({
 AlgoOrdersTable.propTypes = {
   algoOrders: PropTypes.objectOf(PropTypes.shape(ORDER_SHAPE)).isRequired,
   filteredAlgoOrders: PropTypes.objectOf(PropTypes.shape(ORDER_SHAPE)),
-  cancelOrder: PropTypes.func.isRequired,
-  gaCancelOrder: PropTypes.func.isRequired,
-  authToken: PropTypes.string.isRequired,
   renderedInTradingState: PropTypes.bool,
   getMarketPair: PropTypes.func.isRequired,
-  editOrder: PropTypes.func.isRequired,
   showHistory: PropTypes.bool.isRequired,
 }
 

--- a/src/components/AlgoOrdersTable/AlgoOrdersTable.js
+++ b/src/components/AlgoOrdersTable/AlgoOrdersTable.js
@@ -50,8 +50,8 @@ const AlgoOrdersTable = ({
         <VirtualTable
           data={data}
           columns={AOColumns}
-          defaultSortBy='createdAt'
-          defaultSortDirection='ASC'
+          defaultSortBy='lastActive'
+          defaultSortDirection='DESC'
           rowHeight={30}
         />
       )}

--- a/src/components/AlgoOrdersTable/style.scss
+++ b/src/components/AlgoOrdersTable/style.scss
@@ -3,6 +3,7 @@
 .hfui-aolist__wrapper {
   padding-bottom: 8px;
   height: 100%;
+  min-width: 700px;
 
   &_more_info {
     text-transform: uppercase;

--- a/src/components/AlgoOrdersTable/style.scss
+++ b/src/components/AlgoOrdersTable/style.scss
@@ -38,24 +38,11 @@
   }
 }
 
-.icons-cell {
+.hfui-ao-actions {
   display: flex;
   justify-content: space-around;
   align-items: center;
   color: var(--shade-6) !important;
-
-  .edit-order-menu {
-    top: 0% !important;
-    left: 82% !important;
-    min-width: 180px;
-
-    .hfui-navbar__layout-settings__menu-buttons {
-      :hover {
-        color: var(--primary-8) !important;
-        background-color: var(--lighter-background-color) !important;
-      }
-    }
-  }
 
   .more-options-button {
     padding-left: 5px;
@@ -69,4 +56,8 @@
       color: var(--primary-8);
     }
   }
+}
+
+.tooltip__edit-order-menu {
+  padding: 0;
 }

--- a/src/components/Navbar/Navbar.CloseSessionButton.js
+++ b/src/components/Navbar/Navbar.CloseSessionButton.js
@@ -9,7 +9,10 @@ import { changeUIModalState, logInformation } from '../../redux/actions/ui'
 import WSActions from '../../redux/actions/ws'
 import { isElectronApp } from '../../redux/config'
 import { UI_MODAL_KEYS } from '../../redux/constants/modals'
-import { getActiveStrategies, getAllAlgoOrdersArray } from '../../redux/selectors/ws'
+import {
+  getActiveStrategies,
+  getFilteredLocalAlgoOrders,
+} from '../../redux/selectors/ws'
 import { removeCookie } from '../../util/cookies'
 import closeElectronApp from '../../redux/helpers/close_electron_app'
 import { LOG_LEVELS } from '../../constants/logging'
@@ -20,7 +23,7 @@ const homeUrl = process.env.REACT_APP_ENVIRONMENT === 'staging'
 
 const CloseSessionButton = () => {
   const activeStrategies = useSelector(getActiveStrategies)
-  const algoOrders = useSelector(getAllAlgoOrdersArray)
+  const algoOrders = useSelector(getFilteredLocalAlgoOrders)
 
   const needToProcessBeforeCloseApp = !_isEmpty(activeStrategies) || !_isEmpty(algoOrders)
 
@@ -38,15 +41,33 @@ const CloseSessionButton = () => {
   }
 
   const openCloseSessionModal = () => {
-    dispatch(logInformation('Close session requested.', LOG_LEVELS.INFO, 'close_session_requested'))
+    dispatch(
+      logInformation(
+        'Close session requested.',
+        LOG_LEVELS.INFO,
+        'close_session_requested',
+      ),
+    )
 
     if (needToProcessBeforeCloseApp) {
-      dispatch(logInformation('Can\'t close session because there are active strategies or algo orders, offering user to close them first.', LOG_LEVELS.INFO, 'close_session_progress'))
+      dispatch(
+        logInformation(
+          "Can't close session because there are active strategies or algo orders, offering user to close them first.",
+          LOG_LEVELS.INFO,
+          'close_session_progress',
+        ),
+      )
       dispatch(changeUIModalState(UI_MODAL_KEYS.CLOSE_SESSION_MODAL, true))
       return
     }
 
-    dispatch(logInformation('Closing session.', LOG_LEVELS.INFO, 'close_session_success'))
+    dispatch(
+      logInformation(
+        'Closing session.',
+        LOG_LEVELS.INFO,
+        'close_session_success',
+      ),
+    )
     closeElectronApp()
   }
 

--- a/src/modals/AlgoOrderDetailsModal/AlgoOrderDetailsModal.Header.js
+++ b/src/modals/AlgoOrderDetailsModal/AlgoOrderDetailsModal.Header.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AlgoOrderActions from '../../components/AlgoOrdersTable/AlgoOrderActions'
+import PanelIconButton from '../../ui/Panel/Panel.IconButton'
+import { ORDER_SHAPE } from '../../constants/prop-types-shapes'
+
+const AlgoOrderDetailsModalHeader = ({ rowData, onClose }) => {
+  return (
+    <div className='title-container'>
+      <div className='hfui-navbar__layout-settings__title'>
+        {rowData?.name}
+        <span className='sub-title'>{rowData?.alias}</span>
+      </div>
+      <div className='actions-container'>
+        <AlgoOrderActions
+          key={rowData?.gid}
+          order={rowData}
+          isInAlgoOrderDetailsModal
+        />
+        <PanelIconButton
+          onClick={onClose}
+          icon={<i className='icon-cancel' />}
+        />
+      </div>
+    </div>
+  )
+}
+
+AlgoOrderDetailsModalHeader.propTypes = {
+  rowData: PropTypes.shape(ORDER_SHAPE),
+  onClose: PropTypes.func.isRequired,
+}
+
+AlgoOrderDetailsModalHeader.defaultProps = {
+  rowData: {},
+}
+
+export default AlgoOrderDetailsModalHeader

--- a/src/modals/AlgoOrderDetailsModal/AlgoOrderDetailsModal.js
+++ b/src/modals/AlgoOrderDetailsModal/AlgoOrderDetailsModal.js
@@ -21,7 +21,7 @@ import { getAOContext } from '../../util/order'
 import { saveAsJSON } from '../../util/ui'
 import { rowMapping } from '../../components/OrderHistory/OrderHistory.colunms'
 import Scrollbars from '../../ui/Scrollbars'
-import PanelIconButton from '../../ui/Panel/Panel.IconButton'
+import AlgoOrderDetailsModalHeader from './AlgoOrderDetailsModal.Header'
 
 import './style.css'
 
@@ -71,18 +71,7 @@ const AlgoOrderDetailsModal = ({ onClose, algoOrderId }) => {
     <Modal
       onClose={onClose}
       isOpen={isOpen}
-      title={(
-        <div className='title-container'>
-          <div className='hfui-navbar__layout-settings__title'>
-            {rowData?.name}
-            <span className='sub-title'>{rowData?.alias}</span>
-          </div>
-          <PanelIconButton
-            onClick={onClose}
-            icon={<i className='icon-cancel' />}
-          />
-        </div>
-      )}
+      title={<AlgoOrderDetailsModalHeader rowData={rowData} onClose={onClose} />}
       className='hfui-ao-details-modal'
       height={460}
       width={1200}

--- a/src/modals/AlgoOrderDetailsModal/style.scss
+++ b/src/modals/AlgoOrderDetailsModal/style.scss
@@ -22,6 +22,12 @@
         width: 100% !important;
       }
     }
+
+    .actions-container {
+      display: flex;
+      width: 80px;
+      justify-content: space-between;
+    }
   }
 
   .info-title {

--- a/src/modals/CloseSessionModal/CloseSessionModal.js
+++ b/src/modals/CloseSessionModal/CloseSessionModal.js
@@ -11,11 +11,13 @@ import WSActions from '../../redux/actions/ws'
 import { LOG_LEVELS } from '../../constants/logging'
 
 import SessionList from './SessionList'
+import AlgoOrderDetailsModal from '../AlgoOrderDetailsModal'
 
 import './style.css'
 
 const CloseSessionModal = () => {
   const [isLoading, setIsLoading] = useState(false)
+  const [moreInfoAlgoOrderGID, setMoreInfoAlgoOrderGID] = useState(null)
 
   const isOpen = useSelector((state) => getUIModalStateForKey(state, UI_MODAL_KEYS.CLOSE_SESSION_MODAL))
 
@@ -50,32 +52,45 @@ const CloseSessionModal = () => {
     }, 10000)
   }
 
+  const openAODetailsModal = (gid) => {
+    onClose()
+    setMoreInfoAlgoOrderGID(gid)
+  }
+
+  const AODetailsModalClose = () => {
+    setMoreInfoAlgoOrderGID(null)
+    dispatch(UIActions.changeUIModalState(UI_MODAL_KEYS.CLOSE_SESSION_MODAL, true))
+  }
+
   return (
-    <Modal
-      label={t('closeSessionModal.title')}
-      isOpen={isOpen}
-      onClose={onCloseAndLog}
-      onSubmit={onSubmit}
-      width={600}
-    >
-      {isLoading ? <Spinner /> : (
-        <div>
-          <p className='close-session-modal__description'>
-            {t('closeSessionModal.text_1')}
-          </p>
-          <SessionList onModalClose={onClose} />
-          <p>{t('closeSessionModal.text_2')}</p>
-        </div>
-      )}
-      <Modal.Footer>
-        <Modal.Button primary onClick={onSubmit} disabled={isLoading}>
-          {t('closeSessionModal.submitButton')}
-        </Modal.Button>
-        <Modal.Button secondary onClick={onCloseAndLog} disabled={isLoading}>
-          {t('closeSessionModal.closeButton')}
-        </Modal.Button>
-      </Modal.Footer>
-    </Modal>
+    <>
+      <Modal
+        label={t('closeSessionModal.title')}
+        isOpen={isOpen}
+        onClose={onCloseAndLog}
+        onSubmit={onSubmit}
+        width={600}
+      >
+        {isLoading ? <Spinner /> : (
+          <div>
+            <p className='close-session-modal__description'>
+              {t('closeSessionModal.text_1')}
+            </p>
+            <SessionList onModalClose={onClose} openAODetailsModal={openAODetailsModal} />
+            <p>{t('closeSessionModal.text_2')}</p>
+          </div>
+        )}
+        <Modal.Footer>
+          <Modal.Button primary onClick={onSubmit} disabled={isLoading}>
+            {t('closeSessionModal.submitButton')}
+          </Modal.Button>
+          <Modal.Button secondary onClick={onCloseAndLog} disabled={isLoading}>
+            {t('closeSessionModal.closeButton')}
+          </Modal.Button>
+        </Modal.Footer>
+      </Modal>
+      <AlgoOrderDetailsModal onClose={AODetailsModalClose} algoOrderId={moreInfoAlgoOrderGID} />
+    </>
   )
 }
 

--- a/src/modals/CloseSessionModal/SessionList.js
+++ b/src/modals/CloseSessionModal/SessionList.js
@@ -83,7 +83,7 @@ const SessionList = ({ onModalClose, openAODetailsModal }) => {
             className='primary-label'
             onClick={openAODetailsModal.bind(this, order.gid)}
           >
-            {order.label}
+            {order.alias || order.label}
           </span>
           &nbsp;
           <span className='secondary-label'>

--- a/src/modals/CloseSessionModal/SessionList.js
+++ b/src/modals/CloseSessionModal/SessionList.js
@@ -15,12 +15,11 @@ import {
 } from '../../redux/selectors/meta'
 import { changeMode, setCurrentStrategy } from '../../redux/actions/ui'
 import routes from '../../constants/routes'
-import { showActiveOrdersModal } from '../../redux/actions/ao'
 import { getIsPaperTrading } from '../../redux/selectors/ui'
 import { prepareStrategyToLoad } from '../../components/StrategyEditor/StrategyEditor.helpers'
 import { MAIN_MODE } from '../../redux/reducers/ui'
 
-const SessionList = ({ onModalClose }) => {
+const SessionList = ({ onModalClose, openAODetailsModal }) => {
   const activeStrategies = useSelector(getSortedByTimeActiveStrategies())
   const _getMarketPair = useSelector(getMarketPair)
   const isPaperTrading = useSelector(getIsPaperTrading)
@@ -53,10 +52,7 @@ const SessionList = ({ onModalClose }) => {
 
     onModalClose()
   }
-  const onAlgoOrderClick = () => {
-    onModalClose()
-    dispatch(showActiveOrdersModal(true))
-  }
+
   return (
     <ul className='close-session-modal__orders-list'>
       {_map(activeStrategies, (strategy) => (
@@ -83,7 +79,10 @@ const SessionList = ({ onModalClose }) => {
       ))}
       {_map(algoOrders, (order) => (
         <li className='close-session-modal__orders-list-item' key={order.gid}>
-          <span className='primary-label' onClick={onAlgoOrderClick}>
+          <span
+            className='primary-label'
+            onClick={openAODetailsModal.bind(this, order.gid)}
+          >
             {order.label}
           </span>
           &nbsp;
@@ -98,6 +97,7 @@ const SessionList = ({ onModalClose }) => {
 
 SessionList.propTypes = {
   onModalClose: PropTypes.func.isRequired,
+  openAODetailsModal: PropTypes.func.isRequired,
 }
 
 export default SessionList

--- a/src/modals/CloseSessionModal/SessionList.js
+++ b/src/modals/CloseSessionModal/SessionList.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import {
-  getAllAlgoOrdersArray,
+  getFilteredLocalAlgoOrders,
   getSortedByTimeActiveStrategies,
   getSortedByTimeStrategies,
 } from '../../redux/selectors/ws'
@@ -23,7 +23,7 @@ const SessionList = ({ onModalClose, openAODetailsModal }) => {
   const activeStrategies = useSelector(getSortedByTimeActiveStrategies())
   const _getMarketPair = useSelector(getMarketPair)
   const isPaperTrading = useSelector(getIsPaperTrading)
-  const algoOrders = useSelector(getAllAlgoOrdersArray)
+  const algoOrders = useSelector(getFilteredLocalAlgoOrders)
   const savedStrategies = useSelector(getSortedByTimeStrategies)
   const markets = useSelector(getMarketsForExecution)
 

--- a/src/modals/EditOrderModal/style.scss
+++ b/src/modals/EditOrderModal/style.scss
@@ -1,4 +1,6 @@
 .hfui-edit-order-modal__wrapper {
+  border: 2px solid var(--primary-8);
+
   .ao-submit-action,
   .hfui-orderform__layout-actions {
     display: none;

--- a/src/redux/config.js
+++ b/src/redux/config.js
@@ -1,3 +1,5 @@
+import { Recurring } from 'bfx-hf-algo'
+
 const REDUCER_PATHS = {
   WS: 'ws',
   ROUTER: 'router',
@@ -51,6 +53,8 @@ const HONEY_AUTH_URL = `${process.env.REACT_APP_UFX_API_URL}/honey`
 const PASSWORD_MIN_LENGTH = 8
 const PASSWORD_MAX_LENGTH = 64
 
+const HOSTED_ALGO_ORDERS = [Recurring.id]
+
 export {
   REDUCER_PATHS,
   PUB_REST_API_URL,
@@ -71,4 +75,5 @@ export {
   PASSWORD_MAX_LENGTH,
   MARGIN_TRADING_ARTICLE_URL,
   STOP_ORDER_ARTICLE_URL,
+  HOSTED_ALGO_ORDERS,
 }

--- a/src/redux/sagas/ui/on_log.js
+++ b/src/redux/sagas/ui/on_log.js
@@ -1,6 +1,5 @@
 import { put, select } from 'redux-saga/effects'
 import _toUpper from 'lodash/toUpper'
-import _includes from 'lodash/includes'
 
 import WSActions from '../../actions/ws'
 import { getSockets } from '../../selectors/ws'

--- a/src/redux/selectors/ws/get_algo_orders.js
+++ b/src/redux/selectors/ws/get_algo_orders.js
@@ -1,8 +1,10 @@
 import _get from 'lodash/get'
 import _values from 'lodash/values'
+import _includes from 'lodash/includes'
+import _filter from 'lodash/filter'
 
 import { createSelector } from 'reselect'
-import { REDUCER_PATHS } from '../../config'
+import { HOSTED_ALGO_ORDERS, REDUCER_PATHS } from '../../config'
 import { getShowAOsHistory } from '../ao'
 import { getCurrentMode } from '../ui'
 import getAlgoOrdersHistory from './get_algo_orders_history'
@@ -16,6 +18,11 @@ const getAllAlgoOrders = (state) => _get(state, `${path}.algoOrders`, EMPTY_OBJ)
 export const getAllAlgoOrdersArray = createSelector(
   getAllAlgoOrders,
   ({ paper, main }) => _values({ ...paper, ...main }),
+)
+
+export const getFilteredLocalAlgoOrders = createSelector(
+  getAllAlgoOrdersArray,
+  (aos) => _filter(aos, ({ id }) => !_includes(HOSTED_ALGO_ORDERS, id)),
 )
 
 export const getCurrentModeAlgoOrders = createSelector(

--- a/src/redux/selectors/ws/index.js
+++ b/src/redux/selectors/ws/index.js
@@ -22,6 +22,7 @@ import getFilteredAlgoOrdersCount from './get_filtered_algo_orders_count'
 import {
   getCurrentModeAlgoOrders,
   getAllAlgoOrdersArray,
+  getFilteredLocalAlgoOrders,
 } from './get_algo_orders'
 import getNotifications from './get_notifications'
 import getOrderHistory from './get_order_history'
@@ -91,6 +92,7 @@ export {
   getFilteredAtomicOrdersCount,
   getCurrentModeAlgoOrders,
   getAllAlgoOrdersArray,
+  getFilteredLocalAlgoOrders,
   getFilteredAlgoOrders,
   getFilteredAlgoOrdersCount,
   getFavoritePairs,

--- a/src/util/ui.js
+++ b/src/util/ui.js
@@ -45,7 +45,13 @@ export const makeShorterLongName = (name, limit) => _truncate(name, {
   omission: '...',
 })
 
-export const defaultCellRenderer = (content) => (<Truncate>{content}</Truncate>)
+export const defaultCellRenderer = (content) => (
+  <Truncate
+    placement='bottom'
+  >
+    {content}
+  </Truncate>
+)
 
 export const saveAsJSON = (obj, fileName) => {
   const data = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(obj, null, 2))}`


### PR DESCRIPTION
### Asana task:
https://app.asana.com/0/1201849173362898/1204086534669824

### Description:
https://user-images.githubusercontent.com/81973123/222465579-d3731df3-69db-4155-95cc-28e7942110d5.mp4

1. CloseSessionModal renders only local AO (excluding Recurring AOs)
2. On AO click in CloseSessionModal, AO details modal is opened, instead of Active AOs modal (with resuming/cancelling options)
3. Added algo order actions (edit/cancel) into AO details tab
4. Using Tooltip component for algo order actions in AOs list table and AOs details modal
5. Set min width for AOs table

### Related Pull Requests:
...

### Backend Dependencies:
...

### Other Dependencies:
...

