### PR TITLE
(fix) Trading State AO History only displays successful AOs

### DIFF
--- a/src/redux/sagas/ao/request_aos_history.js
+++ b/src/redux/sagas/ao/request_aos_history.js
@@ -1,12 +1,11 @@
 import { put, select } from 'redux-saga/effects'
-import { getAuthToken, getIsAOsHistoryLoaded } from '../../selectors/ws'
+import { getAuthToken } from '../../selectors/ws'
 import WSActions from '../../actions/ws'
 
 export default function* requestAOsHistory({ payload }) {
   const { showAOsHistory } = payload
-  const isHistoryLoaded = yield select(getIsAOsHistoryLoaded)
 
-  if (!showAOsHistory || isHistoryLoaded) {
+  if (!showAOsHistory) {
     return
   }
   const authToken = yield select(getAuthToken)


### PR DESCRIPTION
### Asana task:
[Trading State AO History only displays successful AOs](https://app.asana.com/0/1201849173362898/1203856519336815/f)

### Description:
#### Before:
<img width="704" alt="Screenshot 2023-03-07 at 14 52 09" src="https://user-images.githubusercontent.com/35810911/223458658-bf94aa21-f953-42bb-921b-c6271766e864.png">

User creates an AO order -> connection fails -> AO is not displayed in history due to caching (there is a new order names `df original`, but it's not displayed in history because of caching)

#### Now:
<img width="704" alt="Screenshot 2023-03-07 at 14 49 42" src="https://user-images.githubusercontent.com/35810911/223458795-e63e5f33-fddb-46fd-90c5-b4cc3db27d6a.png">
<img width="1440" alt="Screenshot 2023-03-07 at 14 49 07" src="https://user-images.githubusercontent.com/35810911/223458803-aac67fe4-8a6e-408c-975d-7ff05815b701.png">

User creates an AO order -> connection fails -> AO is displayed in history because we enforce history updates
