### PR TITLE
(improvement) Remove all AO and strategy related keymaps

### DIFF
--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -16,7 +16,6 @@ import { Recurring } from 'bfx-hf-algo'
 import OrderFormTab from './FieldComponents/ui.tab'
 import { isElectronApp } from '../../redux/config'
 import Panel from '../../ui/Panel'
-import { getIsAnyModalOpen } from '../../util/document'
 
 import AOParamSettings from './Orderform.AlgoParams'
 import ConnectingModal from '../APIKeysConfigurateForm/ConnectingModal'
@@ -72,20 +71,11 @@ class OrderForm extends React.Component {
     this.processAOData = this.processAOData.bind(this)
     this.setFieldData = this.setFieldData.bind(this)
     this.validateAOData = this.validateAOData.bind(this)
-    this.handleKeydown = this.handleKeydown.bind(this)
     this.renderAPIStateModal = this.renderAPIStateModal.bind(this)
-  }
-
-  componentDidMount() {
-    window.addEventListener('keydown', this.handleKeydown)
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     return !_isEqual(nextProps, this.props) || !_isEqual(this.state, nextState)
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('keydown', this.handleKeydown)
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -111,22 +101,6 @@ class OrderForm extends React.Component {
       fieldData: {},
       currentLayout: null,
       validationErrors: nextValidationErrors,
-    }
-  }
-
-  handleKeydown(e) {
-    // handle keys only when no modal is open, and it is orderform-details view
-    if (getIsAnyModalOpen() || !this.getIsOrderFormInputsView()) {
-      return
-    }
-
-    const { isAlgoOrder } = this.state
-    const { key } = e
-    if (key === 'Escape') {
-      this.onClearOrderLayout()
-    }
-    if (key === 'Enter' && isAlgoOrder) {
-      this.onSubmit('submit')
     }
   }
 

--- a/src/util/document.js
+++ b/src/util/document.js
@@ -1,1 +1,0 @@
-export const getIsAnyModalOpen = () => !!document.querySelector('#dialog-container .ufx-dialog .background.entered')


### PR DESCRIPTION
### Asana task:
[[GHI-814] Remove all AO and strategy related keymaps](https://app.asana.com/0/1201848935859401/1204114151145290/f)
https://github.com/bitfinexcom/bfx-hf-ui/issues/814

### Description:
 - Removed key listener from Order Form (AOs and Atomic order creation form)
 - Checked the Strategy module for any other key listeners similar to that one - none found.
