### PR TITLE
(fix) Hide AO params menu for atomics

### DIFF
--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -406,6 +406,7 @@ class OrderForm extends React.Component {
       currentLayout,
       helpOpen,
       currentMarket,
+      isAlgoOrder,
     } = this.state
 
     const algoOrders = getAOs(t, showAdvancedAlgos)
@@ -453,7 +454,7 @@ class OrderForm extends React.Component {
                 icon={<Icon name='question' />}
               />
             ),
-            !helpOpen && currentLayout && currentLayout.id && (
+            !helpOpen && currentLayout && currentLayout.id && isAlgoOrder && (
               <AOParamSettings
                 key='ao-settings'
                 algoID={currentLayout.id}


### PR DESCRIPTION
### Asana task:
...

### Description:
As we don't have saving atomic order params endpoint, it should be hidden
![изображение](https://user-images.githubusercontent.com/81973123/225024029-f6dd4486-f739-41c5-9c7d-420db6095a6b.png)


### Related Pull Requests:
...

### Backend Dependencies:
...

### Other Dependencies:
...



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204164394453730